### PR TITLE
Add Unity Editor Yaml serializer

### DIFF
--- a/Assets/UGF.Serialize.Editor.Tests/UGF.Serialize.Editor.Tests.asmdef
+++ b/Assets/UGF.Serialize.Editor.Tests/UGF.Serialize.Editor.Tests.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "UGF.Serialize.Editor.Tests",
+    "rootNamespace": "",
+    "references": [
+        "GUID:e76e47a0b9e0396439161248a194baa5",
+        "GUID:e5736ec7e8ea21d4b8065d34c17b0e50"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/UGF.Serialize.Editor.Tests/UGF.Serialize.Editor.Tests.asmdef.meta
+++ b/Assets/UGF.Serialize.Editor.Tests/UGF.Serialize.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 57b924c6c6aa33c449e6e9da8a7f9451
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/New Serializer Unity Yaml Editor Asset.asset
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/New Serializer Unity Yaml Editor Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89f15c65ac744d5fad35b476b963e6c7, type: 3}
+  m_Name: New Serializer Unity Yaml Editor Asset
+  m_EditorClassIdentifier: 
+  m_name: unity-yaml-text-editor

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/New Serializer Unity Yaml Editor Asset.asset.meta
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/New Serializer Unity Yaml Editor Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 996ac54eef128e9419389d7ac5074c7d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using UGF.Serialize.Editor.Unity;
+using UnityEngine;
+
+namespace UGF.Serialize.Editor.Tests.Unity
+{
+    public class TestSerializerUnityYamlEditor
+    {
+        [Test]
+        public void Serialize()
+        {
+            var serialize = new SerializerUnityYamlEditor();
+            var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
+
+            string text = serialize.Serialize(target);
+
+            Assert.NotNull(text);
+            Assert.Greater(text.Length, 0);
+        }
+
+        [Test]
+        public void Deserialize()
+        {
+            var serialize = new SerializerUnityYamlEditor();
+            var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
+
+            string text = serialize.Serialize(target);
+            var target0 = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(text);
+
+            Assert.AreEqual(target.BoolValue, target0.BoolValue);
+            Assert.AreEqual(target.IntValue, target0.IntValue);
+            Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+    }
+}

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs.meta
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 18e03bbc83944c7d9004145f327931f8
+timeCreated: 1602609903

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditorTarget.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditorTarget.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using UnityEngine;
+
+namespace UGF.Serialize.Editor.Tests.Unity
+{
+    [Serializable]
+    public class TestSerializerUnityYamlEditorTarget : ScriptableObject
+    {
+        [SerializeField] private bool m_boolValue = true;
+        [SerializeField] private int m_intValue = 10;
+        [SerializeField] private float m_floatValue = 10.5F;
+
+        public bool BoolValue { get { return m_boolValue; } set { m_boolValue = value; } }
+        public int IntValue { get { return m_intValue; } set { m_intValue = value; } }
+        public float FloatValue { get { return m_floatValue; } set { m_floatValue = value; } }
+    }
+}

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditorTarget.cs.meta
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditorTarget.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e53a299e970c488583c862e68336762d
+timeCreated: 1602610085

--- a/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
+++ b/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
@@ -2,7 +2,8 @@
     "name": "UGF.Serialize.Editor",
     "rootNamespace": "UGF.Serialize.Editor",
     "references": [
-        "GUID:e76e47a0b9e0396439161248a194baa5"
+        "GUID:e76e47a0b9e0396439161248a194baa5",
+        "GUID:abdd615e45137c74ca2ce9c636c78c15"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityJsonEditorAsset.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityJsonEditorAsset.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UGF.Serialize.Editor.Unity
 {
-    [CreateAssetMenu(menuName = "UGF/Serialize/SerializerUnityJsonEditor", order = 2000)]
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer Unity Json Editor", order = 2000)]
     public class SerializerUnityJsonEditorAsset : SerializerAsset<string>
     {
         [SerializeField] private bool m_readable;

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using UGF.EditorTools.Editor.Yaml;
+using UGF.Serialize.Runtime;
+using Unity.Profiling;
+using Object = UnityEngine.Object;
+
+namespace UGF.Serialize.Editor.Unity
+{
+    public class SerializerUnityYamlEditor : SerializerBase<string>
+    {
+        private static ProfilerMarker m_markerSerialize;
+        private static ProfilerMarker m_markerDeserialize;
+
+#if ENABLE_PROFILER
+        static SerializerUnityYamlEditor()
+        {
+            m_markerSerialize = new ProfilerMarker("SerializerUnityYamlEditor.Serialize");
+            m_markerDeserialize = new ProfilerMarker("SerializerUnityYamlEditor.Deserialize");
+        }
+#endif
+
+        public override string Serialize(object target)
+        {
+            return InternalSerialize(target);
+        }
+
+        public override object Deserialize(Type targetType, string data)
+        {
+            return InternalDeserialize(data);
+        }
+
+        private static string InternalSerialize(object target)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (!(target is Object unityTarget)) throw new ArgumentException("Target must be a Unity object.", nameof(target));
+
+            m_markerSerialize.Begin();
+
+            string result = EditorYamlUtility.ToYaml(unityTarget);
+
+            m_markerSerialize.End();
+
+            return result;
+        }
+
+        private static object InternalDeserialize(string data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            m_markerDeserialize.Begin();
+
+            object target = EditorYamlUtility.FromYaml(data);
+
+            m_markerDeserialize.End();
+
+            return target;
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs.meta
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2cba783cb0bc42ad9ca362d819a48dba
+timeCreated: 1602609075

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditorAsset.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditorAsset.cs
@@ -1,0 +1,19 @@
+﻿using UGF.Serialize.Runtime;
+using UnityEngine;
+
+namespace UGF.Serialize.Editor.Unity
+{
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer Unity Yaml Editor", order = 2000)]
+    public class SerializerUnityYamlEditorAsset : SerializerAsset<string>
+    {
+        protected override ISerializer<string> OnBuildTyped()
+        {
+            return new SerializerUnityYamlEditor();
+        }
+
+        private void Reset()
+        {
+            Name = "unity-yaml-text-editor";
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditorAsset.cs.meta
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditorAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 89f15c65ac744d5fad35b476b963e6c7
+timeCreated: 1602609448

--- a/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatterBinaryAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatterBinaryAsset.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Formatter
 {
-    [CreateAssetMenu(menuName = "UGF/Serialize/SerializerFormatterBinary", order = 2000)]
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer Formatter Binary", order = 2000)]
     public class SerializerFormatterBinaryAsset : SerializerAsset<byte[]>
     {
         protected override ISerializer<byte[]> OnBuildTyped()

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonAsset.cs
@@ -2,7 +2,7 @@
 
 namespace UGF.Serialize.Runtime.Unity
 {
-    [CreateAssetMenu(menuName = "UGF/Serialize/SerializerUnityJson", order = 2000)]
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer Unity Json", order = 2000)]
     public class SerializerUnityJsonAsset : SerializerAsset<string>
     {
         [SerializeField] private bool m_readable;

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Unity
 {
-    [CreateAssetMenu(menuName = "UGF/Serialize/SerializerUnityJsonBytes", order = 2000)]
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer Unity Json Bytes", order = 2000)]
     public class SerializerUnityJsonBytesAsset : SerializerAsset<byte[]>
     {
         protected override ISerializer<byte[]> OnBuildTyped()

--- a/Packages/UGF.Serialize/package.json
+++ b/Packages/UGF.Serialize/package.json
@@ -21,5 +21,7 @@
     "bintray": {
         "registry": "https://api.bintray.com/content/unity-game-framework/public"
     },
-    "dependencies": {}
+    "dependencies": {
+        "com.ugf.editortools": "1.3.1"
+    }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,10 +1,19 @@
 {
   "dependencies": {
+    "com.ugf.editortools": {
+      "version": "1.3.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+    },
     "com.ugf.serialize": {
       "version": "file:UGF.Serialize",
       "depth": 0,
       "source": "embedded",
-      "dependencies": {}
+      "dependencies": {
+        "com.ugf.editortools": "1.3.1"
+      }
     },
     "com.unity.ext.nunit": {
       "version": "1.0.0",


### PR DESCRIPTION
- Add `SerializerUnityYamlEditor` serializer to use Unity Editor Yaml serialization.
- Add `SerializerUnityYamlEditorAsset` scriptableobject asset to handler creation of `SerializerUnityYamlEditor` serializer.
- Add `com.ugf.editortools` of `1.3.1` version dependency.