### PR TITLE
Add optional serializers when UGF.JsonNet and UGF.Yaml packages available

### DIFF
--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b50bfbd525c95f54da12851ad865f2e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Asset.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6d63c99e2b54466ada4393afc0de72c, type: 3}
+  m_Name: New Serializer Json Net Asset
+  m_EditorClassIdentifier: 
+  m_name: jsonnet-text
+  m_readable: 0

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Asset.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 228cdcf7cb0bf4a4da30853cf294bdf1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs
@@ -1,0 +1,95 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UGF.Serialize.Runtime.JsonNet;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace UGF.Serialize.Runtime.Tests.JsonNet
+{
+    public class TestSerializerJsonNet
+    {
+        [Serializable]
+        private class Target
+        {
+            [SerializeField] private bool m_boolValue = true;
+            [SerializeField] private int m_intValue = 10;
+            [SerializeField] private float m_floatValue = 10.5F;
+
+            public bool BoolValue { get { return m_boolValue; } set { m_boolValue = value; } }
+            public int IntValue { get { return m_intValue; } set { m_intValue = value; } }
+            public float FloatValue { get { return m_floatValue; } set { m_floatValue = value; } }
+        }
+
+        [Test]
+        public void Serialize()
+        {
+            var serialize = new SerializerJsonNet();
+            var target = new Target();
+
+            string text = serialize.Serialize(target);
+
+            Assert.NotNull(text);
+            Assert.Greater(text.Length, 0);
+        }
+
+        [Test]
+        public void Deserialize()
+        {
+            var serialize = new SerializerJsonNet();
+            var target = new Target();
+
+            string text = serialize.Serialize(target);
+            var target0 = serialize.Deserialize<Target>(text);
+
+            Assert.AreEqual(target.BoolValue, target0.BoolValue);
+            Assert.AreEqual(target.IntValue, target0.IntValue);
+            Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+
+        [UnityTest]
+        public IEnumerator SerializeAsync()
+        {
+            var serialize = new SerializerJsonNet();
+            var target = new Target();
+
+            Task<string> task = serialize.SerializeAsync(target);
+
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            string text = task.Result;
+
+            Assert.NotNull(text);
+            Assert.Greater(text.Length, 0);
+        }
+
+        [UnityTest]
+        public IEnumerator DeserializeAsync()
+        {
+            var serialize = new SerializerJsonNet();
+            var target = new Target();
+
+            string text = serialize.Serialize(target);
+
+            Task<Target> task = serialize.DeserializeAsync<Target>(text);
+
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            Target target0 = task.Result;
+
+            Assert.AreEqual(target.BoolValue, target0.BoolValue);
+            Assert.AreEqual(target.IntValue, target0.IntValue);
+            Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+    }
+}
+
+#endif

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs
@@ -91,5 +91,4 @@ namespace UGF.Serialize.Runtime.Tests.JsonNet
         }
     }
 }
-
 #endif

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cb694c26f0d446abbf89bfb1832191fd
+timeCreated: 1603035288

--- a/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
+++ b/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
@@ -16,6 +16,17 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.ugf.jsonnet",
+            "expression": "",
+            "define": "UGF_SERIALIZE_JSONNET"
+        },
+        {
+            "name": "com.ugf.yaml",
+            "expression": "",
+            "define": "UGF_SERIALIZE_YAML"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Assets/UGF.Serialize.Runtime.Tests/Yaml.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Yaml.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d03b055a917d9c42a04acb9090288fc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Yaml/New Serializer Yaml Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/Yaml/New Serializer Yaml Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4caebe577ef467ebea1d2af2c13b884, type: 3}
+  m_Name: New Serializer Yaml Asset
+  m_EditorClassIdentifier: 
+  m_name: yaml-text

--- a/Assets/UGF.Serialize.Runtime.Tests/Yaml/New Serializer Yaml Asset.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Yaml/New Serializer Yaml Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9ef6ca6d9ac0c142943f78f4e34d5c1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Yaml/TestSerializerYaml.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Yaml/TestSerializerYaml.cs
@@ -1,0 +1,94 @@
+﻿#if UGF_SERIALIZE_YAML
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UGF.Serialize.Runtime.Yaml;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace UGF.Serialize.Runtime.Tests.Yaml
+{
+    public class TestSerializerYaml
+    {
+        [Serializable]
+        private class Target
+        {
+            [SerializeField] private bool m_boolValue = true;
+            [SerializeField] private int m_intValue = 10;
+            [SerializeField] private float m_floatValue = 10.5F;
+
+            public bool BoolValue { get { return m_boolValue; } set { m_boolValue = value; } }
+            public int IntValue { get { return m_intValue; } set { m_intValue = value; } }
+            public float FloatValue { get { return m_floatValue; } set { m_floatValue = value; } }
+        }
+
+        [Test]
+        public void Serialize()
+        {
+            var serialize = new SerializerYaml();
+            var target = new Target();
+
+            string text = serialize.Serialize(target);
+
+            Assert.NotNull(text);
+            Assert.Greater(text.Length, 0);
+        }
+
+        [Test]
+        public void Deserialize()
+        {
+            var serialize = new SerializerYaml();
+            var target = new Target();
+
+            string text = serialize.Serialize(target);
+            var target0 = serialize.Deserialize<Target>(text);
+
+            Assert.AreEqual(target.BoolValue, target0.BoolValue);
+            Assert.AreEqual(target.IntValue, target0.IntValue);
+            Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+
+        [UnityTest]
+        public IEnumerator SerializeAsync()
+        {
+            var serialize = new SerializerYaml();
+            var target = new Target();
+
+            Task<string> task = serialize.SerializeAsync(target);
+
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            string text = task.Result;
+
+            Assert.NotNull(text);
+            Assert.Greater(text.Length, 0);
+        }
+
+        [UnityTest]
+        public IEnumerator DeserializeAsync()
+        {
+            var serialize = new SerializerYaml();
+            var target = new Target();
+
+            string text = serialize.Serialize(target);
+
+            Task<Target> task = serialize.DeserializeAsync<Target>(text);
+
+            while (!task.IsCompleted)
+            {
+                yield return null;
+            }
+
+            Target target0 = task.Result;
+
+            Assert.AreEqual(target.BoolValue, target0.BoolValue);
+            Assert.AreEqual(target.IntValue, target0.IntValue);
+            Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+    }
+}
+#endif

--- a/Assets/UGF.Serialize.Runtime.Tests/Yaml/TestSerializerYaml.cs.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Yaml/TestSerializerYaml.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 51c2e7a13f1147d390aa53a9b79d01bc
+timeCreated: 1603035950

--- a/Packages/UGF.Serialize/Runtime/JsonNet.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d6ed66038ac540969a14a21125970ffb
+timeCreated: 1602612779

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs
@@ -1,0 +1,77 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System;
+using System.Threading.Tasks;
+using UGF.JsonNet.Runtime;
+using Unity.Profiling;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    public class SerializerJsonNet : SerializerAsyncBase<string>
+    {
+        public bool Readable { get; }
+
+        private static ProfilerMarker m_markerSerialize;
+        private static ProfilerMarker m_markerDeserialize;
+
+#if ENABLE_PROFILER
+        static SerializerJsonNet()
+        {
+            m_markerSerialize = new ProfilerMarker("SerializerJsonNet.Serialize");
+            m_markerDeserialize = new ProfilerMarker("SerializerJsonNet.Deserialize");
+        }
+#endif
+
+        public SerializerJsonNet(bool readable = false)
+        {
+            Readable = readable;
+        }
+
+        public override string Serialize(object target)
+        {
+            return InternalSerialize(target, Readable);
+        }
+
+        public override object Deserialize(Type targetType, string data)
+        {
+            return InternalDeserialize(targetType, data);
+        }
+
+        public override Task<string> SerializeAsync(object target)
+        {
+            return Task.Run(() => InternalSerialize(target, Readable));
+        }
+
+        public override Task<object> DeserializeAsync(Type targetType, string data)
+        {
+            return Task.Run(() => InternalDeserialize(targetType, data));
+        }
+
+        private static string InternalSerialize(object target, bool readable)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+
+            m_markerSerialize.Begin();
+
+            string result = JsonNetUtility.ToJson(target, readable);
+
+            m_markerSerialize.End();
+
+            return result;
+        }
+
+        private static object InternalDeserialize(Type targetType, string data)
+        {
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            m_markerDeserialize.Begin();
+
+            object target = JsonNetUtility.FromJson(data, targetType);
+
+            m_markerDeserialize.End();
+
+            return target;
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f517fd0b044a4357a0f310747007f5a1
+timeCreated: 1602612782

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs
@@ -1,0 +1,24 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using UnityEngine;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer JsonNet", order = 2000)]
+    public class SerializerJsonNetAsset : SerializerAsset<string>
+    {
+        [SerializeField] private bool m_readable;
+
+        public bool Readable { get { return m_readable; } set { m_readable = value; } }
+
+        protected override ISerializer<string> OnBuildTyped()
+        {
+            return new SerializerJsonNet(m_readable);
+        }
+
+        private void Reset()
+        {
+            Name = "jsonnet-text";
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b6d63c99e2b54466ada4393afc0de72c
+timeCreated: 1603035044

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -1,7 +1,10 @@
 {
     "name": "UGF.Serialize.Runtime",
     "rootNamespace": "UGF.Serialize.Runtime",
-    "references": [],
+    "references": [
+        "GUID:63a84d759dbdad34287768b1f164c241",
+        "GUID:45cb6418a66530e4abd8950fdee1ea57"
+    ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
@@ -9,6 +12,17 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.ugf.jsonnet",
+            "expression": "",
+            "define": "UGF_SERIALIZE_JSONNET"
+        },
+        {
+            "name": "com.ugf.yaml",
+            "expression": "",
+            "define": "UGF_SERIALIZE_YAML"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/UGF.Serialize/Runtime/Yaml.meta
+++ b/Packages/UGF.Serialize/Runtime/Yaml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: acea7e5ccb794f83aef10efe6500ec33
+timeCreated: 1603035611

--- a/Packages/UGF.Serialize/Runtime/Yaml/SerializerYaml.cs
+++ b/Packages/UGF.Serialize/Runtime/Yaml/SerializerYaml.cs
@@ -1,0 +1,70 @@
+﻿#if UGF_SERIALIZE_YAML
+using System;
+using System.Threading.Tasks;
+using UGF.Yaml.Runtime;
+using Unity.Profiling;
+
+namespace UGF.Serialize.Runtime.Yaml
+{
+    public class SerializerYaml : SerializerAsyncBase<string>
+    {
+        private static ProfilerMarker m_markerSerialize;
+        private static ProfilerMarker m_markerDeserialize;
+
+#if ENABLE_PROFILER
+        static SerializerYaml()
+        {
+            m_markerSerialize = new ProfilerMarker("SerializerYaml.Serialize");
+            m_markerDeserialize = new ProfilerMarker("SerializerYaml.Deserialize");
+        }
+#endif
+
+        public override string Serialize(object target)
+        {
+            return InternalSerialize(target);
+        }
+
+        public override object Deserialize(Type targetType, string data)
+        {
+            return InternalDeserialize(targetType, data);
+        }
+
+        public override Task<string> SerializeAsync(object target)
+        {
+            return Task.Run(() => InternalSerialize(target));
+        }
+
+        public override Task<object> DeserializeAsync(Type targetType, string data)
+        {
+            return Task.Run(() => InternalDeserialize(targetType, data));
+        }
+
+        private static string InternalSerialize(object target)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+
+            m_markerSerialize.Begin();
+
+            string result = YamlUtility.ToYaml(target);
+
+            m_markerSerialize.End();
+
+            return result;
+        }
+
+        private static object InternalDeserialize(Type targetType, string data)
+        {
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            m_markerDeserialize.Begin();
+
+            object target = YamlUtility.FromYaml(data, targetType);
+
+            m_markerDeserialize.End();
+
+            return target;
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/Yaml/SerializerYaml.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/Yaml/SerializerYaml.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e8162dd04d4947a6bf12f78b4b6c32ee
+timeCreated: 1603035636

--- a/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace UGF.Serialize.Runtime.Yaml
+{
+    [CreateAssetMenu(menuName = "UGF/Serialize/Serializer Yaml", order = 2000)]
+    public class SerializerYamlAsset : SerializerAsset<string>
+    {
+        protected override ISerializer<string> OnBuildTyped()
+        {
+            return new SerializerYaml();
+        }
+
+        private void Reset()
+        {
+            Name = "yaml-text";
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#if UGF_SERIALIZE_YAML
+using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Yaml
 {
@@ -16,3 +17,4 @@ namespace UGF.Serialize.Runtime.Yaml
         }
     }
 }
+#endif

--- a/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f4caebe577ef467ebea1d2af2c13b884
+timeCreated: 1603035790

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ugf.jsonnet": "1.0.0",
+    "com.ugf.jsonnet": "1.1.0",
     "com.ugf.yaml": "1.0.0",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.test-framework": "1.1.18"

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "com.ugf.jsonnet": "1.0.0",
+    "com.ugf.yaml": "1.0.0",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.test-framework": "1.1.18"
   },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,6 +7,15 @@
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
+    "com.ugf.jsonnet": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "2.0.0"
+      },
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
+    },
     "com.ugf.serialize": {
       "version": "file:UGF.Serialize",
       "depth": 0,
@@ -14,6 +23,13 @@
       "dependencies": {
         "com.ugf.editortools": "1.3.1"
       }
+    },
+    "com.ugf.yaml": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.unity.ext.nunit": {
       "version": "1.0.0",
@@ -29,6 +45,13 @@
       "dependencies": {
         "com.unity.test-framework": "1.1.1"
       },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "2.0.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.jsonnet": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
- Add `SerializerJsonNet` serializer and `SerializerJsonNetAsset` asset to use serialization when `UGF.JsonNet` package available in project.
- Add `SerializerYaml` serializer and `SerializerYamlAsset` asset to use serialization when `UGF.Yaml` package available in project.