### PR TITLE
Add object copy using specific serializer

### DIFF
--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityJsonEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityJsonEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using UGF.Serialize.Editor.Unity;
+using UGF.Serialize.Runtime;
 using UnityEngine;
 
 namespace UGF.Serialize.Editor.Tests.Unity
@@ -69,6 +70,22 @@ namespace UGF.Serialize.Editor.Tests.Unity
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerUnityJsonEditor();
+            var target = new Target();
+
+            Target copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
         }
     }
 }

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using UGF.Serialize.Editor.Unity;
+using UGF.Serialize.Runtime;
 using UnityEngine;
 
 namespace UGF.Serialize.Editor.Tests.Unity
@@ -30,6 +31,22 @@ namespace UGF.Serialize.Editor.Tests.Unity
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerUnityYamlEditor();
+            var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
+
+            TestSerializerUnityYamlEditorTarget copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
         }
     }
 }

--- a/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using UGF.Serialize.Runtime.Formatter;
@@ -21,7 +20,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
         [Test]
         public void Serialize()
         {
-            var serializer = new SerializerFormatter(new BinaryFormatter());
+            var serializer = new SerializerFormatter();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -33,7 +32,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
         [Test]
         public void Deserialize()
         {
-            var serializer = new SerializerFormatter(new BinaryFormatter());
+            var serializer = new SerializerFormatter();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -47,7 +46,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
         [UnityTest]
         public IEnumerator SerializeAsync()
         {
-            var serializer = new SerializerFormatter(new BinaryFormatter());
+            var serializer = new SerializerFormatter();
             var target = new Target();
 
             Task<byte[]> task = serializer.SerializeAsync(target);
@@ -66,7 +65,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
         [UnityTest]
         public IEnumerator DeserializeAsync()
         {
-            var serializer = new SerializerFormatter(new BinaryFormatter());
+            var serializer = new SerializerFormatter();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);

--- a/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
@@ -83,5 +83,21 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerFormatter();
+            var target = new Target();
+
+            Target copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
+        }
     }
 }

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestSerializerJsonNet.cs
@@ -89,6 +89,22 @@ namespace UGF.Serialize.Runtime.Tests.JsonNet
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerJsonNet();
+            var target = new Target();
+
+            Target copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
+        }
     }
 }
 #endif

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJson.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJson.cs
@@ -88,5 +88,21 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerUnityJson();
+            var target = new Target();
+
+            Target copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
+        }
     }
 }

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
@@ -89,5 +89,21 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerUnityJsonBytes();
+            var target = new Target();
+
+            Target copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
+        }
     }
 }

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
@@ -26,7 +26,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Serialize()
         {
-            var serializer = new SerializerUnityJsonBytes(Encoding.Default);
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -38,7 +38,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Deserialize()
         {
-            var serializer = new SerializerUnityJsonBytes(Encoding.Default);
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -52,7 +52,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [UnityTest]
         public IEnumerator SerializeAsync()
         {
-            var serializer = new SerializerUnityJsonBytes(Encoding.Default);
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             Task<byte[]> task = serializer.SerializeAsync(target);
@@ -71,7 +71,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [UnityTest]
         public IEnumerator DeserializeAsync()
         {
-            var serializer = new SerializerUnityJsonBytes(Encoding.Default);
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);

--- a/Assets/UGF.Serialize.Runtime.Tests/Yaml/TestSerializerYaml.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Yaml/TestSerializerYaml.cs
@@ -89,6 +89,22 @@ namespace UGF.Serialize.Runtime.Tests.Yaml
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
+
+        [Test]
+        public void Copy()
+        {
+            var serializer = new SerializerYaml();
+            var target = new Target();
+
+            Target copy = SerializeUtility.Copy(target, serializer);
+
+            Assert.NotNull(copy);
+            Assert.AreNotEqual(copy, target);
+            Assert.AreNotSame(copy, target);
+            Assert.AreEqual(copy.BoolValue, target.BoolValue);
+            Assert.AreEqual(copy.IntValue, target.IntValue);
+            Assert.AreEqual(copy.FloatValue, target.FloatValue);
+        }
     }
 }
 #endif

--- a/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatter.cs
+++ b/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using Unity.Profiling;
 
@@ -26,6 +27,14 @@ namespace UGF.Serialize.Runtime.Formatter
             m_markerDeserialize = new ProfilerMarker("SerializerFormatter.Deserialize");
         }
 #endif
+
+        /// <summary>
+        /// Creates serializer with the BinaryFormatter.
+        /// </summary>
+        public SerializerFormatter()
+        {
+            Formatter = new BinaryFormatter();
+        }
 
         /// <summary>
         /// Creates serializer with the specified formatter.

--- a/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatterBinaryAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatterBinaryAsset.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization.Formatters.Binary;
+﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Formatter
@@ -8,7 +9,14 @@ namespace UGF.Serialize.Runtime.Formatter
     {
         protected override ISerializer<byte[]> OnBuildTyped()
         {
-            return new SerializerFormatter(new BinaryFormatter());
+            IFormatter formatter = OnCreateFormatter();
+
+            return new SerializerFormatter(formatter);
+        }
+
+        protected virtual IFormatter OnCreateFormatter()
+        {
+            return new BinaryFormatter();
         }
 
         private void Reset()

--- a/Packages/UGF.Serialize/Runtime/SerializeUtility.cs
+++ b/Packages/UGF.Serialize/Runtime/SerializeUtility.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace UGF.Serialize.Runtime
+{
+    public static class SerializeUtility
+    {
+        public static T Copy<T>(T target, ISerializer serializer) where T : class
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+            object data = serializer.Serialize(target);
+            var copy = serializer.Deserialize<T>(data);
+
+            return copy;
+        }
+
+        public static object Copy(object target, ISerializer serializer)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+            object data = serializer.Serialize(target);
+            object copy = serializer.Deserialize(target.GetType(), data);
+
+            return copy;
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Runtime/SerializeUtility.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/SerializeUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 07c1af0529ef448bbe06b78a34f4d96e
+timeCreated: 1604771116

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytes.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytes.cs
@@ -28,6 +28,14 @@ namespace UGF.Serialize.Runtime.Unity
 #endif
 
         /// <summary>
+        /// Creates serialize with the default encoding.
+        /// </summary>
+        public SerializerUnityJsonBytes()
+        {
+            Encoding = Encoding.Default;
+        }
+
+        /// <summary>
         /// Creates serializer with the specified encoding.
         /// </summary>
         /// <param name="encoding">The encoding used to convert Json data to byte array.</param>

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
@@ -8,7 +8,14 @@ namespace UGF.Serialize.Runtime.Unity
     {
         protected override ISerializer<byte[]> OnBuildTyped()
         {
-            return new SerializerUnityJsonBytes(Encoding.Default);
+            Encoding encoding = OnCreateEncoding();
+
+            return new SerializerUnityJsonBytes(encoding);
+        }
+
+        protected virtual Encoding OnCreateEncoding()
+        {
+            return Encoding.Default;
         }
 
         private void Reset()

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b6
-m_EditorVersionWithRevision: 2020.2.0b6 (24a0f8b56f72)
+m_EditorVersion: 2020.2.0b9
+m_EditorVersionWithRevision: 2020.2.0b9 (ef2968fa77ae)


### PR DESCRIPTION
- Add `SerializeUtility` with `Copy` and `Copy<T>` methods to copy specified target using specific serializer.
- Add default constructors for `SerializerUnityJsonBytes` and `SerializerFormatter` serializers.
- Add `SerializerFormatterBinaryAsset.OnCreateFormatter` overridable method to control formatter creation.
- Add `SerializerUnityJsonBytesAsset.OnCreateEncoding` overridable method to control encoding creation.