### PR TITLE
Add option to extend default serializers

### DIFF
--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Names Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Names Asset.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4069c64c4c645acbd1d8f05819dbf6d, type: 3}
+  m_Name: New Serializer Json Net Convert Names Asset
+  m_EditorClassIdentifier: 
+  m_name: jsonnet-text
+  m_readable: 0
+  m_serializeNames:
+  - m_from: $type
+    m_to: type
+  m_deserializeNames:
+  - m_from: type
+    m_to: $type

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Names Asset.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Names Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ae1dbb35bfa92e49b4a30d458f931d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Types Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Types Asset.asset
@@ -14,11 +14,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_name: jsonnet-text
   m_readable: 0
-  m_serializeNames: []
-  m_deserializeNames: []
+  m_serializeNames:
+  - m_from: $type
+    m_to: type
+  m_deserializeNames:
+  - m_from: type
+    m_to: $type
   m_types:
-  - m_name: Vector2
+  - m_name: target
     m_assembly: 
     m_type:
-      m_value: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral,
-        PublicKeyToken=null
+      m_value: UGF.Serialize.Runtime.Tests.JsonNet.TestSerializerJsonNet+Target,
+        UGF.Serialize.Runtime.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Types Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Types Asset.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb5dddce10fb43d98768e4fb8b8afbbf, type: 3}
+  m_Name: New Serializer Json Net Convert Types Asset
+  m_EditorClassIdentifier: 
+  m_name: jsonnet-text
+  m_readable: 0
+  m_serializeNames: []
+  m_deserializeNames: []
+  m_types:
+  - m_name: Vector2
+    m_assembly: 
+    m_type:
+      m_value: UnityEngine.Vector2, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral,
+        PublicKeyToken=null

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Types Asset.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/New Serializer Json Net Convert Types Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d44c41efb91523240b86e49a22c3c48e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c68ef9e3f44e864bab700b744250d7a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustom.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustom.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_name: jsonnet-text
   m_readable: 1
+  m_indent: 2
   m_serializeNames:
   - m_from: $type
     m_to: type

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustom.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustom.asset
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb5dddce10fb43d98768e4fb8b8afbbf, type: 3}
+  m_Name: SerializerJsonNetCustom
+  m_EditorClassIdentifier: 
+  m_name: jsonnet-text
+  m_readable: 1
+  m_serializeNames:
+  - m_from: $type
+    m_to: type
+  m_deserializeNames:
+  - m_from: type
+    m_to: $type
+  m_types:
+  - m_name: target1
+    m_assembly: 
+    m_type:
+      m_value: UGF.Serialize.Runtime.Tests.JsonNet.TestCustomSerializer+Target1,
+        UGF.Serialize.Runtime.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  - m_name: target2
+    m_assembly: 
+    m_type:
+      m_value: UGF.Serialize.Runtime.Tests.JsonNet.TestCustomSerializer+Target2,
+        UGF.Serialize.Runtime.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustom.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustom.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac7142cc9a768c344b0f5385bcd0dec2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustomResult.json
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustomResult.json
@@ -1,0 +1,14 @@
+﻿{
+  "targets": [
+    {
+      "type": "target1",
+      "intValue": 10,
+      "floatValue": 10.5
+    },
+    {
+      "type": "target2",
+      "boolValue": true,
+      "intValue": 10
+    }
+  ]
+}

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustomResult.json.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/Resources/SerializerJsonNetCustomResult.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2358ea4b5c374fb4cbe36ce9bb56dc26
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestCustomSerializer.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestCustomSerializer.cs
@@ -42,7 +42,7 @@ namespace UGF.Serialize.Runtime.Tests.JsonNet
             string result = serializer.Serialize(target);
             string expected = Resources.Load<TextAsset>("SerializerJsonNetCustomResult").text;
 
-            Assert.AreEqual(expected, $"{result}\n");
+            Assert.AreEqual(expected, $"{result}\r\n");
 
             var result2 = serializer.Deserialize<Target>(result);
 

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestCustomSerializer.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestCustomSerializer.cs
@@ -1,0 +1,58 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace UGF.Serialize.Runtime.Tests.JsonNet
+{
+    public class TestCustomSerializer
+    {
+        private class Target
+        {
+            public List<object> Targets { get; set; } = new List<object>();
+        }
+
+        private class Target1
+        {
+            public int IntValue { get; set; } = 10;
+            public float FloatValue { get; set; } = 10.5F;
+        }
+
+        private class Target2
+        {
+            public bool BoolValue { get; set; } = true;
+            public int IntValue { get; set; } = 10;
+        }
+
+        [Test]
+        public void SerializeAndDeserialize()
+        {
+            var builder = Resources.Load<SerializerAsset>("SerializerJsonNetCustom");
+            var serializer = builder.Build<ISerializer<string>>();
+
+            var target = new Target()
+            {
+                Targets =
+                {
+                    new Target1(),
+                    new Target2()
+                }
+            };
+
+            string result = serializer.Serialize(target);
+            string expected = Resources.Load<TextAsset>("SerializerJsonNetCustomResult").text;
+
+            Assert.AreEqual(expected, $"{result}\n");
+
+            var result2 = serializer.Deserialize<Target>(result);
+
+            Assert.NotNull(result2);
+            Assert.IsNotEmpty(result2.Targets);
+            Assert.AreEqual(2, result2.Targets.Count);
+            Assert.IsInstanceOf<Target1>(result2.Targets[0]);
+            Assert.IsInstanceOf<Target2>(result2.Targets[1]);
+            Assert.Pass(result);
+        }
+    }
+}
+#endif

--- a/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestCustomSerializer.cs.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/JsonNet/TestCustomSerializer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 547129fad7de427ca67ab7d3afc280ea
+timeCreated: 1608657219

--- a/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
+++ b/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
@@ -20,7 +20,7 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "1.2.1",
+            "expression": "1.2.2",
             "define": "UGF_SERIALIZE_JSONNET"
         },
         {

--- a/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
+++ b/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "",
     "references": [
         "GUID:e76e47a0b9e0396439161248a194baa5",
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
         "GUID:27619889b8ba8c24980f49ee34dbb44a"
     ],
     "includePlatforms": [],
@@ -19,12 +20,12 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "",
+            "expression": "1.2.1",
             "define": "UGF_SERIALIZE_JSONNET"
         },
         {
             "name": "com.ugf.yaml",
-            "expression": "",
+            "expression": "1.1.0",
             "define": "UGF_SERIALIZE_YAML"
         }
     ],

--- a/Packages/UGF.Serialize/Editor/JsonNet.meta
+++ b/Packages/UGF.Serialize/Editor/JsonNet.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c7f6673cb7d44ee5815b810d314c5a9a
+timeCreated: 1608579940

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs
@@ -1,0 +1,51 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using UGF.EditorTools.Editor.IMGUI;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UGF.Serialize.Runtime.JsonNet;
+using UnityEditor;
+
+namespace UGF.Serialize.Editor.JsonNet
+{
+    [CustomEditor(typeof(SerializerJsonNetConvertNamesAsset), true)]
+    internal class SerializerJsonNetConvertNamesAssetEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyScript;
+        private SerializedProperty m_propertyReadable;
+        private ReorderableListDrawer m_listSerializeNames;
+        private ReorderableListDrawer m_listDeserializeNames;
+
+        private void OnEnable()
+        {
+            m_propertyScript = serializedObject.FindProperty("m_Script");
+            m_propertyReadable = serializedObject.FindProperty("m_readable");
+            m_listSerializeNames = new SerializerJsonNetConvertNamesListDrawer(serializedObject.FindProperty("m_serializeNames"));
+            m_listDeserializeNames = new SerializerJsonNetConvertNamesListDrawer(serializedObject.FindProperty("m_deserializeNames"));
+
+            m_listSerializeNames.Enable();
+            m_listDeserializeNames.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_listSerializeNames.Disable();
+            m_listDeserializeNames.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    EditorGUILayout.PropertyField(m_propertyScript);
+                }
+
+                EditorGUILayout.PropertyField(m_propertyReadable);
+
+                m_listSerializeNames.DrawGUILayout();
+                m_listDeserializeNames.DrawGUILayout();
+            }
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs
@@ -11,6 +11,7 @@ namespace UGF.Serialize.Editor.JsonNet
     {
         private SerializedProperty m_propertyScript;
         private SerializedProperty m_propertyReadable;
+        private SerializedProperty m_propertyIndent;
         private ReorderableListDrawer m_listSerializeNames;
         private ReorderableListDrawer m_listDeserializeNames;
 
@@ -18,6 +19,7 @@ namespace UGF.Serialize.Editor.JsonNet
         {
             m_propertyScript = serializedObject.FindProperty("m_Script");
             m_propertyReadable = serializedObject.FindProperty("m_readable");
+            m_propertyIndent = serializedObject.FindProperty("m_indent");
             m_listSerializeNames = new SerializerJsonNetConvertNamesListDrawer(serializedObject.FindProperty("m_serializeNames"));
             m_listDeserializeNames = new SerializerJsonNetConvertNamesListDrawer(serializedObject.FindProperty("m_deserializeNames"));
 
@@ -47,6 +49,7 @@ namespace UGF.Serialize.Editor.JsonNet
             }
 
             EditorGUILayout.PropertyField(m_propertyReadable);
+            EditorGUILayout.PropertyField(m_propertyIndent);
 
             m_listSerializeNames.DrawGUILayout();
             m_listDeserializeNames.DrawGUILayout();

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs
@@ -14,7 +14,7 @@ namespace UGF.Serialize.Editor.JsonNet
         private ReorderableListDrawer m_listSerializeNames;
         private ReorderableListDrawer m_listDeserializeNames;
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             m_propertyScript = serializedObject.FindProperty("m_Script");
             m_propertyReadable = serializedObject.FindProperty("m_readable");
@@ -25,7 +25,7 @@ namespace UGF.Serialize.Editor.JsonNet
             m_listDeserializeNames.Enable();
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             m_listSerializeNames.Disable();
             m_listDeserializeNames.Disable();
@@ -35,16 +35,21 @@ namespace UGF.Serialize.Editor.JsonNet
         {
             using (new SerializedObjectUpdateScope(serializedObject))
             {
-                using (new EditorGUI.DisabledScope(true))
-                {
-                    EditorGUILayout.PropertyField(m_propertyScript);
-                }
-
-                EditorGUILayout.PropertyField(m_propertyReadable);
-
-                m_listSerializeNames.DrawGUILayout();
-                m_listDeserializeNames.DrawGUILayout();
+                OnDrawGUILayout();
             }
+        }
+
+        protected virtual void OnDrawGUILayout()
+        {
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.PropertyField(m_propertyScript);
+            }
+
+            EditorGUILayout.PropertyField(m_propertyReadable);
+
+            m_listSerializeNames.DrawGUILayout();
+            m_listDeserializeNames.DrawGUILayout();
         }
     }
 }

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs.meta
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesAssetEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 80a96c6ca9d84d41a750145cf2b8a389
+timeCreated: 1608579943

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesListDrawer.cs
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesListDrawer.cs
@@ -18,13 +18,18 @@ namespace UGF.Serialize.Editor.JsonNet
             SerializedProperty propertyTo = serializedProperty.FindPropertyRelative("m_to");
 
             float space = EditorGUIUtility.standardVerticalSpacing * 2F;
+            float labelWidth = EditorGUIUtility.labelWidth + EditorIMGUIUtility.IndentPerLevel;
 
-            var rectFrom = new Rect(position.x, position.y, position.width * 0.5F, position.height);
-            var rectTo = new Rect(rectFrom.xMax + space, position.y, position.width * 0.5F - space, position.height);
+            var rectFrom = new Rect(position.x, position.y, labelWidth, position.height);
+            var rectTo = new Rect(rectFrom.xMax + space, position.y, position.width - rectFrom.width - space, position.height);
 
-            using (new LabelWidthScope(50F))
+            using (new LabelWidthScope(35F))
             {
                 EditorGUI.PropertyField(rectFrom, propertyFrom);
+            }
+
+            using (new LabelWidthScope(20F))
+            {
                 EditorGUI.PropertyField(rectTo, propertyTo);
             }
         }

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesListDrawer.cs
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesListDrawer.cs
@@ -1,0 +1,43 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using UGF.EditorTools.Editor.IMGUI;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Serialize.Editor.JsonNet
+{
+    internal class SerializerJsonNetConvertNamesListDrawer : ReorderableListDrawer
+    {
+        public SerializerJsonNetConvertNamesListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            SerializedProperty propertyFrom = serializedProperty.FindPropertyRelative("m_from");
+            SerializedProperty propertyTo = serializedProperty.FindPropertyRelative("m_to");
+
+            float space = EditorGUIUtility.standardVerticalSpacing * 2F;
+
+            var rectFrom = new Rect(position.x, position.y, position.width * 0.5F, position.height);
+            var rectTo = new Rect(rectFrom.xMax + space, position.y, position.width * 0.5F - space, position.height);
+
+            using (new LabelWidthScope(50F))
+            {
+                EditorGUI.PropertyField(rectFrom, propertyFrom);
+                EditorGUI.PropertyField(rectTo, propertyTo);
+            }
+        }
+
+        protected override float OnElementHeightContent(SerializedProperty serializedProperty, int index)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        protected override bool OnElementHasVisibleChildren(SerializedProperty serializedProperty)
+        {
+            return false;
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesListDrawer.cs.meta
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertNamesListDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dbb837e783f8408f807df6cf277c6d64
+timeCreated: 1608580167

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertTypesAssetEditor.cs
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertTypesAssetEditor.cs
@@ -1,0 +1,35 @@
+﻿using UGF.EditorTools.Editor.IMGUI;
+using UGF.Serialize.Runtime.JsonNet;
+using UnityEditor;
+
+namespace UGF.Serialize.Editor.JsonNet
+{
+    [CustomEditor(typeof(SerializerJsonNetConvertTypesAsset), true)]
+    internal class SerializerJsonNetConvertTypesAssetEditor : SerializerJsonNetConvertNamesAssetEditor
+    {
+        private ReorderableListDrawer m_listTypes;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            m_listTypes = new ReorderableListDrawer(serializedObject.FindProperty("m_types"));
+
+            m_listTypes.Enable();
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            m_listTypes.Disable();
+        }
+
+        protected override void OnDrawGUILayout()
+        {
+            base.OnDrawGUILayout();
+
+            m_listTypes.DrawGUILayout();
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertTypesAssetEditor.cs.meta
+++ b/Packages/UGF.Serialize/Editor/JsonNet/SerializerJsonNetConvertTypesAssetEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1358417f59e742b287a0d1d68e753ee0
+timeCreated: 1608581883

--- a/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
+++ b/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
@@ -18,7 +18,7 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "1.2.0",
+            "expression": "1.2.1",
             "define": "UGF_SERIALIZE_JSONNET"
         }
     ],

--- a/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
+++ b/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
@@ -15,6 +15,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.ugf.jsonnet",
+            "expression": "1.2.0",
+            "define": "UGF_SERIALIZE_JSONNET"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
+++ b/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
@@ -18,7 +18,7 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "1.2.1",
+            "expression": "1.2.2",
             "define": "UGF_SERIALIZE_JSONNET"
         }
     ],

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs
@@ -11,6 +11,7 @@ namespace UGF.Serialize.Runtime.JsonNet
     {
         public JsonSerializerSettings Settings { get; }
         public bool Readable { get; }
+        public int Indent { get; }
 
         private static ProfilerMarker m_markerSerialize;
         private static ProfilerMarker m_markerDeserialize;
@@ -23,14 +24,17 @@ namespace UGF.Serialize.Runtime.JsonNet
         }
 #endif
 
-        public SerializerJsonNet(bool readable = false) : this(JsonNetUtility.DefaultSettings, readable)
+        public SerializerJsonNet(bool readable = false, int indent = 2) : this(JsonNetUtility.DefaultSettings, readable, indent)
         {
         }
 
-        public SerializerJsonNet(JsonSerializerSettings settings, bool readable = false)
+        public SerializerJsonNet(JsonSerializerSettings settings, bool readable = false, int indent = 2)
         {
+            if (indent < 0) throw new ArgumentOutOfRangeException(nameof(indent));
+
             Settings = settings ?? throw new ArgumentNullException(nameof(settings));
             Readable = readable;
+            Indent = indent;
         }
 
         public override string Serialize(object target)

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNet.cs
@@ -59,7 +59,14 @@ namespace UGF.Serialize.Runtime.JsonNet
 
         protected virtual string OnSerialize(object target)
         {
-            return JsonNetUtility.ToJson(target, Settings, Readable);
+            string result = JsonNetUtility.ToJson(target, Settings);
+
+            if (Readable)
+            {
+                result = JsonNetUtility.Format(result, Readable, Indent);
+            }
+
+            return result;
         }
 
         protected virtual object OnDeserialize(Type targetType, string data)

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs
@@ -7,12 +7,14 @@ namespace UGF.Serialize.Runtime.JsonNet
     public class SerializerJsonNetAsset : SerializerAsset<string>
     {
         [SerializeField] private bool m_readable;
+        [SerializeField] private int m_indent;
 
         public bool Readable { get { return m_readable; } set { m_readable = value; } }
+        public int Indent { get { return m_indent; } set { m_indent = value; } }
 
         protected override ISerializer<string> OnBuildTyped()
         {
-            return new SerializerJsonNet(m_readable);
+            return new SerializerJsonNet(m_readable, m_indent);
         }
 
         private void Reset()

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs
@@ -36,7 +36,7 @@ namespace UGF.Serialize.Runtime.JsonNet
 
             if (Readable)
             {
-                result = JsonNetUtility.Format(result);
+                result = JsonNetUtility.Format(result, true, Indent);
             }
 
             return result;

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using UGF.JsonNet.Runtime;
 using UGF.JsonNet.Runtime.Converters;
 
 namespace UGF.Serialize.Runtime.JsonNet
@@ -11,11 +12,11 @@ namespace UGF.Serialize.Runtime.JsonNet
         public Dictionary<string, string> SerializeNames { get; } = new Dictionary<string, string>();
         public Dictionary<string, string> DeserializeNames { get; } = new Dictionary<string, string>();
 
-        public SerializerJsonNetConvertNames(bool readable = false) : base(readable)
+        public SerializerJsonNetConvertNames(bool readable = false, int indent = 2) : base(readable, indent)
         {
         }
 
-        public SerializerJsonNetConvertNames(JsonSerializerSettings settings, bool readable = false) : base(settings, readable)
+        public SerializerJsonNetConvertNames(JsonSerializerSettings settings, bool readable = false, int indent = 2) : base(settings, readable, indent)
         {
         }
 
@@ -27,6 +28,18 @@ namespace UGF.Serialize.Runtime.JsonNet
         protected override JsonReader OnCreateReader(Type targetType, string data)
         {
             return new ConvertPropertyNameReader(DeserializeNames, data);
+        }
+
+        protected override string OnSerialize(object target)
+        {
+            string result = base.OnSerialize(target);
+
+            if (Readable)
+            {
+                result = JsonNetUtility.Format(result);
+            }
+
+            return result;
         }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs
@@ -1,0 +1,33 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using UGF.JsonNet.Runtime.Converters;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    public class SerializerJsonNetConvertNames : SerializerJsonNetCustom
+    {
+        public Dictionary<string, string> SerializeNames { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> DeserializeNames { get; } = new Dictionary<string, string>();
+
+        public SerializerJsonNetConvertNames(bool readable = false) : base(readable)
+        {
+        }
+
+        public SerializerJsonNetConvertNames(JsonSerializerSettings settings, bool readable = false) : base(settings, readable)
+        {
+        }
+
+        protected override JsonWriter OnCreateWriter(object target)
+        {
+            return new ConvertPropertyNameWriter(SerializeNames);
+        }
+
+        protected override JsonReader OnCreateReader(Type targetType, string data)
+        {
+            return new ConvertPropertyNameReader(DeserializeNames, data);
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNames.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83a2544c54ce41d2ab6ccfc5303d91db
+timeCreated: 1608579072

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs
@@ -31,7 +31,7 @@ namespace UGF.Serialize.Runtime.JsonNet
 
         protected override ISerializer<string> OnBuildTyped()
         {
-            var serializer = new SerializerJsonNetConvertNames(Readable);
+            var serializer = new SerializerJsonNetConvertNames(Readable, Indent);
 
             SetupNames(serializer);
 

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs
@@ -1,0 +1,65 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer JsonNet Convert Names", order = 2000)]
+    public class SerializerJsonNetConvertNamesAsset : SerializerJsonNetAsset
+    {
+        [SerializeField] private List<ConvertNameData> m_serializeNames = new List<ConvertNameData>();
+        [SerializeField] private List<ConvertNameData> m_deserializeNames = new List<ConvertNameData>();
+
+        public List<ConvertNameData> SerializeNames { get { return m_serializeNames; } }
+        public List<ConvertNameData> DeserializeNames { get { return m_deserializeNames; } }
+
+        [Serializable]
+        public struct ConvertNameData
+        {
+            [SerializeField] private string m_from;
+            [SerializeField] private string m_to;
+
+            public string From { get { return m_from; } set { m_from = value; } }
+            public string To { get { return m_to; } set { m_to = value; } }
+
+            public bool IsValid()
+            {
+                return !string.IsNullOrEmpty(m_from) && !string.IsNullOrEmpty(m_to);
+            }
+        }
+
+        protected override ISerializer<string> OnBuildTyped()
+        {
+            var serializer = new SerializerJsonNetConvertNames();
+
+            SetupNames(serializer);
+
+            return serializer;
+        }
+
+        protected virtual void SetupNames(SerializerJsonNetConvertNames serializer)
+        {
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+
+            for (int i = 0; i < m_serializeNames.Count; i++)
+            {
+                ConvertNameData data = m_serializeNames[i];
+
+                if (!data.IsValid()) throw new ArgumentException("Value should be valid.", nameof(data));
+
+                serializer.SerializeNames.Add(data.From, data.To);
+            }
+
+            for (int i = 0; i < m_deserializeNames.Count; i++)
+            {
+                ConvertNameData data = m_deserializeNames[i];
+
+                if (!data.IsValid()) throw new ArgumentException("Value should be valid.", nameof(data));
+
+                serializer.DeserializeNames.Add(data.From, data.To);
+            }
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs
@@ -31,7 +31,7 @@ namespace UGF.Serialize.Runtime.JsonNet
 
         protected override ISerializer<string> OnBuildTyped()
         {
-            var serializer = new SerializerJsonNetConvertNames();
+            var serializer = new SerializerJsonNetConvertNames(Readable);
 
             SetupNames(serializer);
 

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertNamesAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e4069c64c4c645acbd1d8f05819dbf6d
+timeCreated: 1608579309

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertTypesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertTypesAsset.cs
@@ -44,7 +44,7 @@ namespace UGF.Serialize.Runtime.JsonNet
 
             settings.SerializationBinder = binder;
 
-            var serializer = new SerializerJsonNetConvertNames(settings, Readable);
+            var serializer = new SerializerJsonNetConvertNames(settings, Readable, Indent);
 
             SetupNames(serializer);
 

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertTypesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertTypesAsset.cs
@@ -1,0 +1,78 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using UGF.EditorTools.Runtime.IMGUI.Types;
+using UGF.JsonNet.Runtime;
+using UGF.JsonNet.Runtime.Converters;
+using UnityEngine;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer JsonNet Convert Types", order = 2000)]
+    public class SerializerJsonNetConvertTypesAsset : SerializerJsonNetConvertNamesAsset
+    {
+        [SerializeField] private List<ConvertTypeData> m_types = new List<ConvertTypeData>();
+
+        public List<ConvertTypeData> Types { get { return m_types; } }
+
+        [Serializable]
+        public struct ConvertTypeData
+        {
+            [SerializeField] private string m_name;
+            [SerializeField] private string m_assembly;
+            [TypeReferenceDropdown]
+            [SerializeField] private TypeReference<object> m_type;
+
+            public string Name { get { return m_name; } set { m_name = value; } }
+            public string Assembly { get { return m_assembly; } set { m_assembly = value; } }
+            public TypeReference<object> Type { get { return m_type; } set { m_type = value; } }
+
+            public bool IsValid()
+            {
+                return m_type.HasValue && !string.IsNullOrEmpty(m_name);
+            }
+        }
+
+        protected override ISerializer<string> OnBuildTyped()
+        {
+            var binder = new ConvertTypeNameBinder();
+
+            SetupTypes(binder.Provider);
+
+            JsonSerializerSettings settings = JsonNetUtility.CreateDefault();
+
+            settings.SerializationBinder = binder;
+
+            var serializer = new SerializerJsonNetConvertNames(settings, Readable);
+
+            SetupNames(serializer);
+
+            return serializer;
+        }
+
+        protected virtual void SetupTypes(IConvertTypeProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+
+            for (int i = 0; i < m_types.Count; i++)
+            {
+                ConvertTypeData data = m_types[i];
+
+                if (!data.IsValid()) throw new ArgumentException("Value should be valid.", nameof(data));
+
+                Type type = data.Type.Get();
+
+                if (!string.IsNullOrEmpty(data.Assembly))
+                {
+                    provider.Add(type, data.Name, data.Assembly);
+                }
+                else
+                {
+                    provider.Add(type, data.Name);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertTypesAsset.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetConvertTypesAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eb5dddce10fb43d98768e4fb8b8afbbf
+timeCreated: 1608581125

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
@@ -37,22 +37,20 @@ namespace UGF.Serialize.Runtime.JsonNet
         {
             JsonSerializer serializer = OnCreateSerializer();
 
-            using (JsonWriter writer = OnCreateWriter(target))
-            {
-                serializer.Serialize(writer, target);
+            using JsonWriter writer = OnCreateWriter(target);
 
-                return writer.ToString();
-            }
+            serializer.Serialize(writer, target);
+
+            return writer.ToString();
         }
 
         protected override object OnDeserialize(Type targetType, string data)
         {
             JsonSerializer serializer = OnCreateSerializer();
 
-            using (JsonReader reader = OnCreateReader(targetType, data))
-            {
-                return serializer.Deserialize(reader, targetType);
-            }
+            using JsonReader reader = OnCreateReader(targetType, data);
+
+            return serializer.Deserialize(reader, targetType);
         }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
@@ -25,7 +25,7 @@ namespace UGF.Serialize.Runtime.JsonNet
 
         protected virtual JsonWriter OnCreateWriter(object target)
         {
-            return new SerializerJsonNetWriter(new StringWriter(new StringBuilder(), CultureInfo.InvariantCulture));
+            return new SerializerJsonNetWriter(new StringWriter(CultureInfo.InvariantCulture));
         }
 
         protected virtual JsonReader OnCreateReader(Type targetType, string data)

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
@@ -1,0 +1,59 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using UGF.JsonNet.Runtime;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    public class SerializerJsonNetCustom : SerializerJsonNet
+    {
+        public SerializerJsonNetCustom(bool readable = false) : this(JsonNetUtility.DefaultSettings, readable)
+        {
+        }
+
+        public SerializerJsonNetCustom(JsonSerializerSettings settings, bool readable = false) : base(settings, readable)
+        {
+        }
+
+        protected virtual JsonSerializer OnCreateSerializer()
+        {
+            return JsonSerializer.Create(Settings);
+        }
+
+        protected virtual JsonWriter OnCreateWriter(object target)
+        {
+            return new SerializerJsonNetWriter(new StringWriter(new StringBuilder(), CultureInfo.InvariantCulture));
+        }
+
+        protected virtual JsonReader OnCreateReader(Type targetType, string data)
+        {
+            return new JsonTextReader(new StringReader(data));
+        }
+
+        protected override string OnSerialize(object target)
+        {
+            JsonSerializer serializer = OnCreateSerializer();
+
+            using (JsonWriter writer = OnCreateWriter(target))
+            {
+                serializer.Serialize(writer, target);
+
+                return writer.ToString();
+            }
+        }
+
+        protected override object OnDeserialize(Type targetType, string data)
+        {
+            JsonSerializer serializer = OnCreateSerializer();
+
+            using (JsonReader reader = OnCreateReader(targetType, data))
+            {
+                return serializer.Deserialize(reader, targetType);
+            }
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs
@@ -2,19 +2,17 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using Newtonsoft.Json;
-using UGF.JsonNet.Runtime;
 
 namespace UGF.Serialize.Runtime.JsonNet
 {
     public class SerializerJsonNetCustom : SerializerJsonNet
     {
-        public SerializerJsonNetCustom(bool readable = false) : this(JsonNetUtility.DefaultSettings, readable)
+        public SerializerJsonNetCustom(bool readable = false, int indent = 2) : base(readable, indent)
         {
         }
 
-        public SerializerJsonNetCustom(JsonSerializerSettings settings, bool readable = false) : base(settings, readable)
+        public SerializerJsonNetCustom(JsonSerializerSettings settings, bool readable = false, int indent = 2) : base(settings, readable, indent)
         {
         }
 

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetCustom.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ade0d9a14bc0455d9c76930ea23bb140
+timeCreated: 1608577635

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetWriter.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetWriter.cs
@@ -1,0 +1,22 @@
+﻿#if UGF_SERIALIZE_JSONNET
+using System.IO;
+using Newtonsoft.Json;
+
+namespace UGF.Serialize.Runtime.JsonNet
+{
+    public class SerializerJsonNetWriter : JsonTextWriter
+    {
+        public TextWriter Writer { get; }
+
+        public SerializerJsonNetWriter(TextWriter writer) : base(writer)
+        {
+            Writer = writer;
+        }
+
+        public override string ToString()
+        {
+            return Writer.ToString();
+        }
+    }
+}
+#endif

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetWriter.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetWriter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9a1dabda61ab414bb83c628386013f19
+timeCreated: 1608578744

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -16,12 +16,12 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "",
+            "expression": "1.2.0",
             "define": "UGF_SERIALIZE_JSONNET"
         },
         {
             "name": "com.ugf.yaml",
-            "expression": "",
+            "expression": "1.1.0",
             "define": "UGF_SERIALIZE_YAML"
         }
     ],

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -18,7 +18,7 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "1.2.0",
+            "expression": "1.2.1",
             "define": "UGF_SERIALIZE_JSONNET"
         },
         {

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -5,7 +5,8 @@
         "GUID:63a84d759dbdad34287768b1f164c241",
         "GUID:45cb6418a66530e4abd8950fdee1ea57",
         "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
-        "GUID:088d00b6871540e44bce58af1a3f0f17"
+        "GUID:088d00b6871540e44bce58af1a3f0f17",
+        "GUID:5bd6d7319b96dab4b887fb59cd3ad7b7"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -18,7 +18,7 @@
     "versionDefines": [
         {
             "name": "com.ugf.jsonnet",
-            "expression": "1.2.1",
+            "expression": "1.2.2",
             "define": "UGF_SERIALIZE_JSONNET"
         },
         {

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:63a84d759dbdad34287768b1f164c241",
         "GUID:45cb6418a66530e4abd8950fdee1ea57",
-        "GUID:6c7389a7d4bbed54e96eb1e71a69798e"
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
+        "GUID:088d00b6871540e44bce58af1a3f0f17"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Serialize/package.json
+++ b/Packages/UGF.Serialize/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "com.ugf.builder": "2.0.0",
-    "com.ugf.editortools": "1.7.0"
+    "com.ugf.editortools": "1.8.1"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ugf.jsonnet": "1.2.0",
+    "com.ugf.jsonnet": "1.2.1",
     "com.ugf.yaml": "1.1.0",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.20"

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.ugf.jsonnet": "1.1.0",
-    "com.ugf.yaml": "1.0.0",
+    "com.ugf.jsonnet": "1.2.0",
+    "com.ugf.yaml": "1.1.0",
     "com.unity.ide.rider": "3.0.3",
-    "com.unity.test-framework": "1.1.19"
+    "com.unity.test-framework": "1.1.20"
   },
   "scopedRegistries": [
     {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ugf.jsonnet": "1.2.1",
+    "com.ugf.jsonnet": "1.2.2",
     "com.ugf.yaml": "1.1.0",
     "com.unity.ide.rider": "3.0.3",
     "com.unity.test-framework": "1.1.20"

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,7 +8,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.editortools": {
-      "version": "1.7.0",
+      "version": "1.8.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -29,7 +29,7 @@
       "source": "embedded",
       "dependencies": {
         "com.ugf.builder": "2.0.0",
-        "com.ugf.editortools": "1.7.0"
+        "com.ugf.editortools": "1.8.1"
       }
     },
     "com.ugf.yaml": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -15,7 +15,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.jsonnet": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -33,14 +33,14 @@
       }
     },
     "com.ugf.yaml": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.unity.ext.nunit": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -63,11 +63,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.19",
+      "version": "1.1.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.ext.nunit": "1.0.5",
+        "com.unity.ext.nunit": "1.0.6",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -15,7 +15,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.jsonnet": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -15,7 +15,7 @@
       "url": "https://api.bintray.com/npm/unity-game-framework/public"
     },
     "com.ugf.jsonnet": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.0b12
-m_EditorVersionWithRevision: 2020.2.0b12 (92852ae685d8)
+m_EditorVersion: 2020.2.0f1
+m_EditorVersionWithRevision: 2020.2.0f1 (3721df5a8b28)


### PR DESCRIPTION
- Add `SerializerJsonNet.OnSerialize()` and `OnDeserialize()` overridable methods used to implement custom `JsonNet` serialization.
- Add `SerializerJsonNetCustom` class to implement `JsonNet` serialization with custom reader and writer.
- Add `SerializerJsonNetConvertNames` and `SerializerJsonNetConvertNamesAsset` to create and use `JsonNet` serializer which can convert property names during serialization and deserialization.
- Add `SerializerJsonNetConvertTypesAsset` which create `SerializerJsonNetConvertNames` serializer with `ConvertTypeNameBinder` binder used to convert type information for specific types.
- Add `SerializerYaml.OnSerialize()` and `OnDeserialize()` overridable methods used to implement custom serialization with `YamlDotNet`.
- Change `SerializerJsonNet` to use `JsonSerializerSettings` settings for `JsonNet` serialization and `Indent` value to specify indentation with readable formatting.
- Change `SerializerYaml` to use specified `ISerializer` and `IDeserializer` serializers from `YamlDotNet`.