### PR TITLE
Remove name and data type from serializer builder

### DIFF
--- a/Assets/UGF.Serialize.Runtime.Tests/TestSerializerProvider.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/TestSerializerProvider.cs
@@ -206,8 +206,8 @@ namespace UGF.Serialize.Runtime.Tests
             provider.Add("text", text);
             provider.Add("bytes", bytes);
 
-            string name0 = provider.GetName(text);
-            string name1 = provider.GetName(bytes);
+            string name0 = provider.GetId(text);
+            string name1 = provider.GetId(bytes);
 
             Assert.AreEqual("text", name0);
             Assert.AreEqual("bytes", name1);
@@ -223,8 +223,8 @@ namespace UGF.Serialize.Runtime.Tests
             provider.Add("text", text);
             provider.Add("bytes", bytes);
 
-            bool result0 = provider.TryGetName(text, out string name0);
-            bool result1 = provider.TryGetName(bytes, out string name1);
+            bool result0 = provider.TryGetId(text, out string name0);
+            bool result1 = provider.TryGetId(bytes, out string name1);
 
             Assert.True(result0);
             Assert.True(result1);

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityJsonEditorAsset.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityJsonEditorAsset.cs
@@ -14,10 +14,5 @@ namespace UGF.Serialize.Editor.Unity
         {
             return new SerializerUnityJsonEditor(m_readable);
         }
-
-        private void Reset()
-        {
-            Name = "unity-json-text-editor";
-        }
     }
 }

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditorAsset.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditorAsset.cs
@@ -10,10 +10,5 @@ namespace UGF.Serialize.Editor.Unity
         {
             return new SerializerUnityYamlEditor();
         }
-
-        private void Reset()
-        {
-            Name = "unity-yaml-text-editor";
-        }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatterBinaryAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatterBinaryAsset.cs
@@ -18,10 +18,5 @@ namespace UGF.Serialize.Runtime.Formatter
         {
             return new BinaryFormatter();
         }
-
-        private void Reset()
-        {
-            Name = "formatter-binary";
-        }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/ISerializerBuilder.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializerBuilder.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using UGF.Builder.Runtime;
+﻿using UGF.Builder.Runtime;
 
 namespace UGF.Serialize.Runtime
 {
     public interface ISerializerBuilder : IBuilder<ISerializer>
     {
-        string Name { get; }
-        Type DataType { get; }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/ISerializerProvider.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializerProvider.cs
@@ -14,24 +14,24 @@ namespace UGF.Serialize.Runtime
         int DataTypesCount { get; }
 
         /// <summary>
-        /// Adds the specified serialize by the specified name.
+        /// Adds the specified serialize by the specified id.
         /// </summary>
-        /// <param name="name">The name of the serializer.</param>
+        /// <param name="id">The id of the serializer.</param>
         /// <param name="serializer">The serializer to add.</param>
-        void Add(string name, ISerializer serializer);
+        void Add(string id, ISerializer serializer);
 
         /// <summary>
-        /// Removes a serializer by the specified name.
+        /// Removes a serializer by the specified id.
         /// </summary>
-        /// <param name="name">The name of the serializer.</param>
-        bool Remove<T>(string name);
+        /// <param name="id">The id of the serializer.</param>
+        bool Remove<T>(string id);
 
         /// <summary>
-        /// Removes a serializer by the specified name and that support the specified type of the data.
+        /// Removes a serializer by the specified id and that support the specified type of the data.
         /// </summary>
         /// <param name="dataType">The type of the data that serializer support.</param>
-        /// <param name="name">The name of the serializer.</param>
-        bool Remove(Type dataType, string name);
+        /// <param name="id">The id of the serializer.</param>
+        bool Remove(Type dataType, string id);
 
         /// <summary>
         /// Removes all serializers.
@@ -50,32 +50,32 @@ namespace UGF.Serialize.Runtime
         void Clear(Type dataType);
 
         /// <summary>
-        /// Gets the serializer by the specified name and that support the specified type of the data.
+        /// Gets the serializer by the specified id and that support the specified type of the data.
         /// </summary>
-        /// <param name="name">The name of the serializer.</param>
-        ISerializer<T> Get<T>(string name);
+        /// <param name="id">The id of the serializer.</param>
+        ISerializer<T> Get<T>(string id);
 
         /// <summary>
-        /// Gets the serializer by the specified name and that support the specified type of the data.
+        /// Gets the serializer by the specified id and that support the specified type of the data.
         /// </summary>
         /// <param name="dataType">The type of the data that serializer support.</param>
-        /// <param name="name">The name of the serializer.</param>
-        ISerializer Get(Type dataType, string name);
+        /// <param name="id">The id of the serializer.</param>
+        ISerializer Get(Type dataType, string id);
 
         /// <summary>
-        /// Tries to get the serializer by the specified name and that support the specified type of the data.
+        /// Tries to get the serializer by the specified id and that support the specified type of the data.
         /// </summary>
-        /// <param name="name">The name of the serializer.</param>
+        /// <param name="id">The id of the serializer.</param>
         /// <param name="serializer">The found serializer.</param>
-        bool TryGet<T>(string name, out ISerializer<T> serializer);
+        bool TryGet<T>(string id, out ISerializer<T> serializer);
 
         /// <summary>
-        /// Tries to get the serializer by the specified name and that support the specified type of the data.
+        /// Tries to get the serializer by the specified id and that support the specified type of the data.
         /// </summary>
         /// <param name="dataType">The type of the data that serializer support.</param>
-        /// <param name="name">The name of the serializer.</param>
+        /// <param name="id">The id of the serializer.</param>
         /// <param name="serializer">The found serializer.</param>
-        bool TryGet(Type dataType, string name, out ISerializer serializer);
+        bool TryGet(Type dataType, string id, out ISerializer serializer);
 
         /// <summary>
         /// Gets the collection of the serializers which support the specified type of the data.
@@ -102,17 +102,17 @@ namespace UGF.Serialize.Runtime
         bool TryGetSerializers(Type dataType, out IReadOnlyDictionary<string, ISerializer> serializers);
 
         /// <summary>
-        /// Gets the name of the specified serializer.
+        /// Gets the id of the specified serializer.
         /// </summary>
         /// <param name="serializer">The serializer to get name of.</param>
-        string GetName(ISerializer serializer);
+        string GetId(ISerializer serializer);
 
         /// <summary>
-        /// Tries to get the name of the specified serializer.
+        /// Tries to get the id of the specified serializer.
         /// </summary>
-        /// <param name="serializer">The serializer to get name of.</param>
-        /// <param name="name">The found name.</param>
-        bool TryGetName(ISerializer serializer, out string name);
+        /// <param name="serializer">The serializer to get id of.</param>
+        /// <param name="id">The found id.</param>
+        bool TryGetId(ISerializer serializer, out string id);
 
         /// <summary>
         /// Gets the collection of the all types of the data.

--- a/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/JsonNet/SerializerJsonNetAsset.cs
@@ -16,11 +16,6 @@ namespace UGF.Serialize.Runtime.JsonNet
         {
             return new SerializerJsonNet(m_readable, m_indent);
         }
-
-        private void Reset()
-        {
-            Name = "jsonnet-text";
-        }
     }
 }
 #endif

--- a/Packages/UGF.Serialize/Runtime/SerializerAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/SerializerAsset.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using UGF.Builder.Runtime;
-using UnityEngine;
+﻿using UGF.Builder.Runtime;
 
 namespace UGF.Serialize.Runtime
 {
     public abstract class SerializerAsset : BuilderAsset<ISerializer>, ISerializerBuilder
     {
-        [SerializeField] private string m_name;
-
-        public string Name { get { return m_name; } set { m_name = value; } }
-
-        public abstract Type DataType { get; }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/SerializerAsset`1.cs
+++ b/Packages/UGF.Serialize/Runtime/SerializerAsset`1.cs
@@ -1,11 +1,7 @@
-﻿using System;
-
-namespace UGF.Serialize.Runtime
+﻿namespace UGF.Serialize.Runtime
 {
     public abstract class SerializerAsset<TData> : SerializerAsset
     {
-        public override Type DataType { get; } = typeof(TData);
-
         public new ISerializer<TData> Build()
         {
             return OnBuildTyped();

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonAsset.cs
@@ -13,10 +13,5 @@ namespace UGF.Serialize.Runtime.Unity
         {
             return new SerializerUnityJson(m_readable);
         }
-
-        private void Reset()
-        {
-            Name = "unity-json-text";
-        }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
@@ -17,10 +17,5 @@ namespace UGF.Serialize.Runtime.Unity
         {
             return Encoding.Default;
         }
-
-        private void Reset()
-        {
-            Name = "unity-json-bytes";
-        }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Yaml/SerializerYamlAsset.cs
@@ -10,11 +10,6 @@ namespace UGF.Serialize.Runtime.Yaml
         {
             return new SerializerYaml();
         }
-
-        private void Reset()
-        {
-            Name = "yaml-text";
-        }
     }
 }
 #endif


### PR DESCRIPTION
- Remove `Name` and `DataType` properties from `ISerializerBuilder`.
- Change `ISerializerProvider` to work with ids instead of names.