### PR TITLE
Add text to bytes serializer

### DIFF
--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd7f2e0d8a6836d47881bdb32ce3b49d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/New Serializer Text To Bytes Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/New Serializer Text To Bytes Asset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b7246be0e4842e6b84a618fba5ec0e4, type: 3}
+  m_Name: New Serializer Text To Bytes Asset
+  m_EditorClassIdentifier: 
+  m_text: {fileID: 0}

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/New Serializer Text To Bytes Asset.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/New Serializer Text To Bytes Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 30b94fe218d595742a00ef10eabd5a1f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f8f02af609361746b7f11f9cdeddbc7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerTextToBytes.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerTextToBytes.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b7246be0e4842e6b84a618fba5ec0e4, type: 3}
+  m_Name: TestSerializerTextToBytes
+  m_EditorClassIdentifier: 
+  m_text: {fileID: 11400000, guid: c656a7737a073d4418ed140a3c6e4eda, type: 2}

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerTextToBytes.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerTextToBytes.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43011d8428500a549846c83cb70c82d5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerUnityJson.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerUnityJson.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 25344ec798e94fecbc3e15c142230040, type: 3}
+  m_Name: TestSerializerUnityJson
+  m_EditorClassIdentifier: 
+  m_readable: 0

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerUnityJson.asset.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/Resources/TestSerializerUnityJson.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c656a7737a073d4418ed140a3c6e4eda
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UGF.Serialize.Runtime.Bytes;
 using UGF.Serialize.Runtime.Unity;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -25,7 +26,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
         [Test]
         public void Serialize()
         {
-            var serializer = new SerializerUnityJsonBytes();
+            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -37,7 +38,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
         [Test]
         public void Deserialize()
         {
-            var serializer = new SerializerUnityJsonBytes();
+            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -51,7 +52,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
         [UnityTest]
         public IEnumerator SerializeAsync()
         {
-            var serializer = new SerializerUnityJsonBytes();
+            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
             Task<byte[]> task = serializer.SerializeAsync(target);
@@ -70,7 +71,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
         [UnityTest]
         public IEnumerator DeserializeAsync()
         {
-            var serializer = new SerializerUnityJsonBytes();
+            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -92,7 +93,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
         [Test]
         public void Copy()
         {
-            var serializer = new SerializerUnityJsonBytes();
+            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
             Target copy = SerializeUtility.Copy(target, serializer);

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
@@ -1,13 +1,12 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using UGF.Serialize.Runtime.Bytes;
 using UGF.Serialize.Runtime.Unity;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace UGF.Serialize.Runtime.Tests.Unity
+namespace UGF.Serialize.Runtime.Tests.Bytes
 {
     public class TestSerializerTextToBytes
     {
@@ -26,7 +25,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Serialize()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -38,7 +37,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Deserialize()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -52,7 +51,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [UnityTest]
         public IEnumerator SerializeAsync()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             Task<byte[]> task = serializer.SerializeAsync(target);
@@ -71,7 +70,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [UnityTest]
         public IEnumerator DeserializeAsync()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -93,7 +92,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Copy()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             Target copy = SerializeUtility.Copy(target, serializer);

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5cb31dcf64664f9ca077695c54b40729
+timeCreated: 1615653404

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytesAsset.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytesAsset.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+using UGF.Serialize.Runtime.Bytes;
+using UnityEngine;
+
+namespace UGF.Serialize.Runtime.Tests.Bytes
+{
+    public class TestSerializerTextToBytesAsset
+    {
+        [Test]
+        public void Build()
+        {
+            var asset = Resources.Load<SerializerAsset>("TestSerializerTextToBytes");
+            ISerializer serializer = asset.Build();
+
+            Assert.NotNull(serializer);
+            Assert.IsInstanceOf<SerializerTextToBytes>(serializer);
+        }
+    }
+}

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytesAsset.cs.meta
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytesAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e529f770495e4121a4eca1be93934b75
+timeCreated: 1615653659

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Collections;
+using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using UGF.Serialize.Runtime.Bytes;
 using UGF.Serialize.Runtime.Unity;
 using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace UGF.Serialize.Runtime.Tests.Unity
 {
-    public class TestSerializerTextToBytes
+    public class TestSerializerUnityJsonBytes
     {
         [Serializable]
         private class Target
@@ -26,7 +26,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Serialize()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -38,7 +38,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Deserialize()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -52,7 +52,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [UnityTest]
         public IEnumerator SerializeAsync()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             Task<byte[]> task = serializer.SerializeAsync(target);
@@ -71,7 +71,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [UnityTest]
         public IEnumerator DeserializeAsync()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             byte[] bytes = serializer.Serialize(target);
@@ -93,7 +93,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         [Test]
         public void Copy()
         {
-            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+            var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
             Target copy = SerializeUtility.Copy(target, serializer);

--- a/Packages/UGF.Serialize/Runtime/Bytes.meta
+++ b/Packages/UGF.Serialize/Runtime/Bytes.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b9a5fc34ebc45bf87187b1ce65055b2
+timeCreated: 1615652914

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytes.cs
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytes.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Unity.Profiling;
+
+namespace UGF.Serialize.Runtime.Bytes
+{
+    public class SerializerTextToBytes : SerializerAsyncBase<byte[]>
+    {
+        public Encoding Encoding { get; }
+        public ISerializer<string> Serializer { get; }
+
+        private static ProfilerMarker m_markerSerialize;
+        private static ProfilerMarker m_markerDeserialize;
+
+#if ENABLE_PROFILER
+        static SerializerTextToBytes()
+        {
+            m_markerSerialize = new ProfilerMarker("SerializerTextToBytes.Serialize");
+            m_markerDeserialize = new ProfilerMarker("SerializerTextToBytes.Deserialize");
+        }
+#endif
+
+        public SerializerTextToBytes(ISerializer<string> serializer) : this(Encoding.Default, serializer)
+        {
+        }
+
+        public SerializerTextToBytes(Encoding encoding, ISerializer<string> serializer)
+        {
+            Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+            Serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        }
+
+        public override byte[] Serialize(object target)
+        {
+            return InternalSerialize(Encoding, Serializer, target);
+        }
+
+        public override object Deserialize(Type targetType, byte[] data)
+        {
+            return InternalDeserialize(Encoding, Serializer, targetType, data);
+        }
+
+        public override Task<byte[]> SerializeAsync(object target)
+        {
+            return Task.Run(() => InternalSerialize(Encoding, Serializer, target));
+        }
+
+        public override Task<object> DeserializeAsync(Type targetType, byte[] data)
+        {
+            return Task.Run(() => InternalDeserialize(Encoding, Serializer, targetType, data));
+        }
+
+        private static byte[] InternalSerialize(Encoding encoding, ISerializer<string> serializer, object target)
+        {
+            if (encoding == null) throw new ArgumentNullException(nameof(encoding));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+            if (target == null) throw new ArgumentNullException(nameof(target));
+
+            m_markerSerialize.Begin();
+
+            string text = serializer.Serialize(target);
+            byte[] result = encoding.GetBytes(text);
+
+            m_markerSerialize.End();
+
+            return result;
+        }
+
+        private static object InternalDeserialize(Encoding encoding, ISerializer<string> serializer, Type targetType, byte[] data)
+        {
+            if (encoding == null) throw new ArgumentNullException(nameof(encoding));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            m_markerDeserialize.Begin();
+
+            string text = encoding.GetString(data);
+            object result = serializer.Deserialize(targetType, text);
+
+            m_markerDeserialize.End();
+
+            return result;
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytes.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytes.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1b4008c0ea7d40519dd4024901241362
+timeCreated: 1615652919

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace UGF.Serialize.Runtime.Bytes
+{
+    [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer Text to Bytes", order = 2000)]
+    public class SerializerTextToBytesAsset : SerializerAsset<byte[]>
+    {
+        [SerializeField] private SerializerAsset m_text;
+
+        public SerializerAsset Text { get { return m_text; } set { m_text = value; } }
+
+        protected override ISerializer<byte[]> OnBuildTyped()
+        {
+            var serializer = m_text.Build<ISerializer<string>>();
+
+            return new SerializerTextToBytes(serializer);
+        }
+    }
+}

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs.meta
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3b7246be0e4842e6b84a618fba5ec0e4
+timeCreated: 1615653201


### PR DESCRIPTION
- Add `SerializerTextToBytes` used with `ISerializer<string>` to convert text to bytes array using any text serializer.
- Add `SerializerTextToBytesAsset` asset to build text to bytes serializer.