### PR TITLE
Deprecate serializer provider

### DIFF
--- a/Assets/UGF.Serialize.Runtime.Tests/TestSerializerProvider.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/TestSerializerProvider.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 namespace UGF.Serialize.Runtime.Tests
 {
+    [Obsolete]
     public class TestSerializerProvider
     {
         private class SerializerText : SerializerBase<string>

--- a/Packages/UGF.Serialize/Runtime/ISerializerProvider.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializerProvider.cs
@@ -6,6 +6,7 @@ namespace UGF.Serialize.Runtime
     /// <summary>
     /// Represents provider of the serializers.
     /// </summary>
+    [Obsolete("ISerializerProvider has been deprecated. Use 'IProvider' from 'UGF.RuntimeTools' instead.")]
     public interface ISerializerProvider
     {
         /// <summary>

--- a/Packages/UGF.Serialize/Runtime/SerializerProvider.cs
+++ b/Packages/UGF.Serialize/Runtime/SerializerProvider.cs
@@ -7,6 +7,7 @@ namespace UGF.Serialize.Runtime
     /// <summary>
     /// Represents provider of the serializers.
     /// </summary>
+    [Obsolete("ISerializerProvider has been deprecated. Use 'IProvider' from 'UGF.RuntimeTools' instead.")]
     public class SerializerProvider : ISerializerProvider
     {
         public int DataTypesCount { get { return m_serializers.Count; } }


### PR DESCRIPTION
- Deprecate `SerializerProvider` and `ISerializerProvider` classes use `IProvider<TKey, TValue>` from _UGF.RuntimeTools_ package instead.