### PR TITLE
Fix missing dependency for JsonUtility class

### DIFF
--- a/Packages/UGF.Serialize/package.json
+++ b/Packages/UGF.Serialize/package.json
@@ -19,6 +19,7 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
+    "com.unity.modules.jsonserialize": "1.0.0",
     "com.ugf.builder": "2.0.0",
     "com.ugf.editortools": "1.8.1"
   }

--- a/Packages/UGF.Serialize/package.json
+++ b/Packages/UGF.Serialize/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "com.unity.modules.jsonserialize": "1.0.0",
-    "com.ugf.builder": "2.0.0",
-    "com.ugf.editortools": "1.8.1"
+    "com.ugf.builder": "2.0.1",
+    "com.ugf.editortools": "1.11.1"
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "3.0.5",
-    "com.unity.test-framework": "1.1.24"
+    "com.unity.ide.rider": "3.0.7",
+    "com.unity.test-framework": "1.1.27"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -31,14 +31,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.5",
+      "version": "3.0.7",
       "depth": 0,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.ext.nunit": "1.0.6"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.1.24",
+      "version": "1.1.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -19,6 +19,7 @@
       "depth": 0,
       "source": "embedded",
       "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
         "com.ugf.builder": "2.0.0",
         "com.ugf.editortools": "1.8.1"
       }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "com.ugf.builder": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
     "com.ugf.editortools": {
-      "version": "1.8.1",
+      "version": "1.11.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
@@ -20,8 +20,8 @@
       "source": "embedded",
       "dependencies": {
         "com.unity.modules.jsonserialize": "1.0.0",
-        "com.ugf.builder": "2.0.0",
-        "com.ugf.editortools": "1.8.1"
+        "com.ugf.builder": "2.0.1",
+        "com.ugf.editortools": "1.11.1"
       }
     },
     "com.unity.ext.nunit": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.2.6f1
-m_EditorVersionWithRevision: 2020.2.6f1 (8a2143876886)
+m_EditorVersion: 2020.3.9f1
+m_EditorVersionWithRevision: 2020.3.9f1 (108be757e447)


### PR DESCRIPTION
- Add dependencies: `com.unity.modules.jsonserialize` of `1.0.0` version.
- Change dependencies: `com.ugf.builder` to `2.0.1` and `com.ugf.editortools` to `1.11.1` version.