### PR TITLE
Change serializers to work with empty data

### DIFF
--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityJsonEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityJsonEditor.cs
@@ -47,6 +47,17 @@ namespace UGF.Serialize.Editor.Tests.Unity
         }
 
         [Test]
+        public void DeserializeEmpty()
+        {
+            var serialize = new SerializerUnityJsonEditor();
+
+            var target = serialize.Deserialize<Target>(string.Empty);
+
+            Assert.NotNull(target);
+            Assert.IsInstanceOf<Target>(target);
+        }
+
+        [Test]
         public void SerializeScriptableObject()
         {
             var serialize = new SerializerUnityJsonEditor();
@@ -70,6 +81,17 @@ namespace UGF.Serialize.Editor.Tests.Unity
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+
+        [Test]
+        public void DeserializeScriptableObjectEmpty()
+        {
+            var serialize = new SerializerUnityJsonEditor();
+
+            var target = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty);
+
+            Assert.NotNull(target);
+            Assert.IsInstanceOf<TestSerializerUnityYamlEditorTarget>(target);
         }
 
         [Test]

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using UGF.Serialize.Editor.Unity;
 using UGF.Serialize.Runtime;
 using UnityEngine;
@@ -38,10 +39,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
         {
             var serialize = new SerializerUnityYamlEditor();
 
-            var target = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty);
-
-            Assert.NotNull(target);
-            Assert.IsInstanceOf<TestSerializerUnityYamlEditorTarget>(target);
+            Assert.Throws<NotSupportedException>(() => serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty));
         }
 
         [Test]

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
@@ -34,6 +34,17 @@ namespace UGF.Serialize.Editor.Tests.Unity
         }
 
         [Test]
+        public void DeserializeEmpty()
+        {
+            var serialize = new SerializerUnityYamlEditor();
+
+            var target = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty);
+
+            Assert.NotNull(target);
+            Assert.IsInstanceOf<TestSerializerUnityYamlEditorTarget>(target);
+        }
+
+        [Test]
         public void Copy()
         {
             var serializer = new SerializerUnityYamlEditor();

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
@@ -49,6 +49,17 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
 
+        [Test]
+        public void DeserializeEmpty()
+        {
+            var serializer = new SerializerTextToBytes(new SerializerUnityJson());
+
+            var target = serializer.Deserialize<Target>(Array.Empty<byte>());
+
+            Assert.NotNull(target);
+            Assert.IsInstanceOf<Target>(target);
+        }
+
         [UnityTest]
         public IEnumerator SerializeAsync()
         {

--- a/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
@@ -43,6 +43,17 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
 
+        [Test]
+        public void DeserializeEmpty()
+        {
+            var serializer = new SerializerFormatter();
+
+            var target = serializer.Deserialize<Target>(Array.Empty<byte>());
+
+            Assert.NotNull(target);
+            Assert.IsInstanceOf<Target>(target);
+        }
+
         [UnityTest]
         public IEnumerator SerializeAsync()
         {

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJson.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJson.cs
@@ -48,6 +48,20 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
         }
 
+        [Test]
+        public void DeserializeEmpty()
+        {
+            var serialize = new SerializerUnityJson();
+
+            var target0 = serialize.Deserialize<Target>(string.Empty);
+            var target1 = serialize.Deserialize<Target>("{}");
+
+            Assert.NotNull(target0);
+            Assert.NotNull(target1);
+            Assert.IsInstanceOf<Target>(target0);
+            Assert.IsInstanceOf<Target>(target1);
+        }
+
         [UnityTest]
         public IEnumerator SerializeAsync()
         {

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using UGF.Serialize.Runtime.Unity;
@@ -47,6 +46,20 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
             Assert.AreEqual(target.FloatValue, target0.FloatValue);
+        }
+
+        [Test]
+        public void DeserializeEmpty()
+        {
+            var serialize = new SerializerUnityJsonBytes();
+
+            var target0 = serialize.Deserialize<Target>(Array.Empty<byte>());
+            var target1 = serialize.Deserialize<Target>(Array.Empty<byte>());
+
+            Assert.NotNull(target0);
+            Assert.NotNull(target1);
+            Assert.IsInstanceOf<Target>(target0);
+            Assert.IsInstanceOf<Target>(target1);
         }
 
         [UnityTest]

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs
@@ -44,6 +44,8 @@ namespace UGF.Serialize.Editor.Unity
 
         private static object InternalDeserialize(string data)
         {
+            if (string.IsNullOrEmpty(data)) throw new NotSupportedException("Deserializing empty Yaml data into Unity object not supported.");
+
             m_markerDeserialize.Begin();
 
             object target = EditorYamlUtility.FromYaml(data);

--- a/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatter.cs
+++ b/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatter.cs
@@ -52,7 +52,7 @@ namespace UGF.Serialize.Runtime.Formatter
 
         protected override object OnDeserialize(Type targetType, byte[] data)
         {
-            return InternalDeserialize(Formatter, data);
+            return InternalDeserialize(Formatter, targetType, data);
         }
 
         protected override Task<byte[]> OnSerializeAsync(object target)
@@ -62,7 +62,7 @@ namespace UGF.Serialize.Runtime.Formatter
 
         protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data)
         {
-            return Task.Run(() => InternalDeserialize(Formatter, data));
+            return Task.Run(() => InternalDeserialize(Formatter, targetType, data));
         }
 
         private static byte[] InternalSerialize(IFormatter formatter, object target)
@@ -80,12 +80,22 @@ namespace UGF.Serialize.Runtime.Formatter
             return result;
         }
 
-        private static object InternalDeserialize(IFormatter formatter, byte[] data)
+        private static object InternalDeserialize(IFormatter formatter, Type targetType, byte[] data)
         {
             m_markerDeserialize.Begin();
 
-            using var stream = new MemoryStream(data);
-            object result = formatter.Deserialize(stream);
+            object result;
+
+            if (data.Length > 0)
+            {
+                using var stream = new MemoryStream(data);
+
+                result = formatter.Deserialize(stream);
+            }
+            else
+            {
+                result = Activator.CreateInstance(targetType);
+            }
 
             m_markerDeserialize.End();
 

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJson.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJson.cs
@@ -68,6 +68,8 @@ namespace UGF.Serialize.Runtime.Unity
 
         private static object InternalDeserialize(Type targetType, string data)
         {
+            if (data == string.Empty) data = "{}";
+
             m_markerDeserialize.Begin();
 
             object target = JsonUtility.FromJson(data, targetType);

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytes.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytes.cs
@@ -80,7 +80,7 @@ namespace UGF.Serialize.Runtime.Unity
         {
             m_markerDeserialize.Begin();
 
-            string text = encoding.GetString(data);
+            string text = data.Length > 0 ? encoding.GetString(data) : "{}";
             object result = JsonUtility.FromJson(text, targetType);
 
             m_markerDeserialize.End();


### PR DESCRIPTION
- Change `SerializerUnityYamlEditor` to throw not supported exception when deserialize empty data.
- Change `SerializerFormatter` to create empty object when deserialize with empty data.
- Change `SerializerUnityJson` and `SerializerUnityJsonBytes` to create empty object when deserialize with empty data.