### PR TITLE
Add context object for serialize and deserialize methods

### DIFF
--- a/Assets/UGF.Serialize.Editor.Tests/UGF.Serialize.Editor.Tests.asmdef
+++ b/Assets/UGF.Serialize.Editor.Tests/UGF.Serialize.Editor.Tests.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:e76e47a0b9e0396439161248a194baa5",
-        "GUID:e5736ec7e8ea21d4b8065d34c17b0e50"
+        "GUID:e5736ec7e8ea21d4b8065d34c17b0e50",
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityJsonEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityJsonEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Editor.Unity;
 using UGF.Serialize.Runtime;
 using UnityEngine;
@@ -26,7 +27,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serialize = new SerializerUnityJsonEditor();
             var target = new Target();
 
-            string text = serialize.Serialize(target);
+            string text = serialize.Serialize(target, new Context());
 
             Assert.NotNull(text);
             Assert.Greater(text.Length, 0);
@@ -38,8 +39,8 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serialize = new SerializerUnityJsonEditor();
             var target = new Target();
 
-            string text = serialize.Serialize(target);
-            var target0 = serialize.Deserialize<Target>(text);
+            string text = serialize.Serialize(target, new Context());
+            var target0 = serialize.Deserialize<Target>(text, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -51,7 +52,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
         {
             var serialize = new SerializerUnityJsonEditor();
 
-            var target = serialize.Deserialize<Target>(string.Empty);
+            var target = serialize.Deserialize<Target>(string.Empty, new Context());
 
             Assert.NotNull(target);
             Assert.IsInstanceOf<Target>(target);
@@ -63,7 +64,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serialize = new SerializerUnityJsonEditor();
             var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
 
-            string text = serialize.Serialize(target);
+            string text = serialize.Serialize(target, new Context());
 
             Assert.NotNull(text);
             Assert.Greater(text.Length, 0);
@@ -75,8 +76,8 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serialize = new SerializerUnityJsonEditor();
             var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
 
-            string text = serialize.Serialize(target);
-            var target0 = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(text);
+            string text = serialize.Serialize(target, new Context());
+            var target0 = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(text, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -88,7 +89,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
         {
             var serialize = new SerializerUnityJsonEditor();
 
-            var target = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty);
+            var target = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty, new Context());
 
             Assert.NotNull(target);
             Assert.IsInstanceOf<TestSerializerUnityYamlEditorTarget>(target);
@@ -100,7 +101,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serializer = new SerializerUnityJsonEditor();
             var target = new Target();
 
-            Target copy = SerializeUtility.Copy(target, serializer);
+            Target copy = SerializeUtility.Copy(target, serializer, new Context());
 
             Assert.NotNull(copy);
             Assert.AreNotEqual(copy, target);

--- a/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
+++ b/Assets/UGF.Serialize.Editor.Tests/Unity/TestSerializerUnityYamlEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Editor.Unity;
 using UGF.Serialize.Runtime;
 using UnityEngine;
@@ -14,7 +15,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serialize = new SerializerUnityYamlEditor();
             var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
 
-            string text = serialize.Serialize(target);
+            string text = serialize.Serialize(target, new Context());
 
             Assert.NotNull(text);
             Assert.Greater(text.Length, 0);
@@ -26,8 +27,8 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serialize = new SerializerUnityYamlEditor();
             var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
 
-            string text = serialize.Serialize(target);
-            var target0 = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(text);
+            string text = serialize.Serialize(target, new Context());
+            var target0 = serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(text, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -39,7 +40,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
         {
             var serialize = new SerializerUnityYamlEditor();
 
-            Assert.Throws<NotSupportedException>(() => serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty));
+            Assert.Throws<NotSupportedException>(() => serialize.Deserialize<TestSerializerUnityYamlEditorTarget>(string.Empty, new Context()));
         }
 
         [Test]
@@ -48,7 +49,7 @@ namespace UGF.Serialize.Editor.Tests.Unity
             var serializer = new SerializerUnityYamlEditor();
             var target = ScriptableObject.CreateInstance<TestSerializerUnityYamlEditorTarget>();
 
-            TestSerializerUnityYamlEditorTarget copy = SerializeUtility.Copy(target, serializer);
+            TestSerializerUnityYamlEditorTarget copy = SerializeUtility.Copy(target, serializer, new Context());
 
             Assert.NotNull(copy);
             Assert.AreNotEqual(copy, target);

--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/TestSerializerTextToBytes.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Runtime.Bytes;
 using UGF.Serialize.Runtime.Unity;
 using UnityEngine;
@@ -29,7 +30,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
             var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
+            byte[] bytes = serializer.Serialize(target, new Context());
 
             Assert.NotNull(bytes);
             Assert.Greater(bytes.Length, 0);
@@ -41,8 +42,8 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
             var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
-            var target0 = serializer.Deserialize<Target>(bytes);
+            byte[] bytes = serializer.Serialize(target, new Context());
+            var target0 = serializer.Deserialize<Target>(bytes, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -54,7 +55,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
         {
             var serializer = new SerializerTextToBytes(new SerializerUnityJson());
 
-            var target = serializer.Deserialize<Target>(Array.Empty<byte>());
+            var target = serializer.Deserialize<Target>(Array.Empty<byte>(), new Context());
 
             Assert.NotNull(target);
             Assert.IsInstanceOf<Target>(target);
@@ -66,7 +67,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
             var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
-            Task<byte[]> task = serializer.SerializeAsync(target);
+            Task<byte[]> task = serializer.SerializeAsync(target, new Context());
 
             while (!task.IsCompleted)
             {
@@ -85,9 +86,9 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
             var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
+            byte[] bytes = serializer.Serialize(target, new Context());
 
-            Task<Target> task = serializer.DeserializeAsync<Target>(bytes);
+            Task<Target> task = serializer.DeserializeAsync<Target>(bytes, new Context());
 
             while (!task.IsCompleted)
             {
@@ -107,7 +108,7 @@ namespace UGF.Serialize.Runtime.Tests.Bytes
             var serializer = new SerializerTextToBytes(new SerializerUnityJson());
             var target = new Target();
 
-            Target copy = SerializeUtility.Copy(target, serializer);
+            Target copy = SerializeUtility.Copy(target, serializer, new Context());
 
             Assert.NotNull(copy);
             Assert.AreNotEqual(copy, target);

--- a/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Formatter/TestSerializerFormatter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Runtime.Formatter;
 using UnityEngine.TestTools;
 
@@ -23,7 +24,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             var serializer = new SerializerFormatter();
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
+            byte[] bytes = serializer.Serialize(target, new Context());
 
             Assert.NotNull(bytes);
             Assert.Greater(bytes.Length, 0);
@@ -35,8 +36,8 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             var serializer = new SerializerFormatter();
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
-            var target0 = serializer.Deserialize<Target>(bytes);
+            byte[] bytes = serializer.Serialize(target, new Context());
+            var target0 = serializer.Deserialize<Target>(bytes, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -48,7 +49,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
         {
             var serializer = new SerializerFormatter();
 
-            var target = serializer.Deserialize<Target>(Array.Empty<byte>());
+            var target = serializer.Deserialize<Target>(Array.Empty<byte>(), new Context());
 
             Assert.NotNull(target);
             Assert.IsInstanceOf<Target>(target);
@@ -60,7 +61,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             var serializer = new SerializerFormatter();
             var target = new Target();
 
-            Task<byte[]> task = serializer.SerializeAsync(target);
+            Task<byte[]> task = serializer.SerializeAsync(target, new Context());
 
             while (!task.IsCompleted)
             {
@@ -79,9 +80,9 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             var serializer = new SerializerFormatter();
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
+            byte[] bytes = serializer.Serialize(target, new Context());
 
-            Task<Target> task = serializer.DeserializeAsync<Target>(bytes);
+            Task<Target> task = serializer.DeserializeAsync<Target>(bytes, new Context());
 
             while (!task.IsCompleted)
             {
@@ -101,7 +102,7 @@ namespace UGF.Serialize.Runtime.Tests.Formatter
             var serializer = new SerializerFormatter();
             var target = new Target();
 
-            Target copy = SerializeUtility.Copy(target, serializer);
+            Target copy = SerializeUtility.Copy(target, serializer, new Context());
 
             Assert.NotNull(copy);
             Assert.AreNotEqual(copy, target);

--- a/Assets/UGF.Serialize.Runtime.Tests/TestSerializer.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/TestSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime.Tests
 {
@@ -7,12 +8,12 @@ namespace UGF.Serialize.Runtime.Tests
     {
         private class Target : Serializer<string>
         {
-            protected override object OnSerialize(object target)
+            protected override object OnSerialize(object target, IContext context)
             {
                 return null;
             }
 
-            protected override object OnDeserialize(Type targetType, string data)
+            protected override object OnDeserialize(Type targetType, string data, IContext context)
             {
                 return null;
             }

--- a/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
+++ b/Assets/UGF.Serialize.Runtime.Tests/UGF.Serialize.Runtime.Tests.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:e76e47a0b9e0396439161248a194baa5",
         "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
-        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -17,17 +18,6 @@
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"
     ],
-    "versionDefines": [
-        {
-            "name": "com.ugf.jsonnet",
-            "expression": "1.2.2",
-            "define": "UGF_SERIALIZE_JSONNET"
-        },
-        {
-            "name": "com.ugf.yaml",
-            "expression": "1.1.0",
-            "define": "UGF_SERIALIZE_YAML"
-        }
-    ],
+    "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJson.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJson.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Runtime.Unity;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -28,7 +29,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serialize = new SerializerUnityJson();
             var target = new Target();
 
-            string text = serialize.Serialize(target);
+            string text = serialize.Serialize(target, new Context());
 
             Assert.NotNull(text);
             Assert.Greater(text.Length, 0);
@@ -40,8 +41,8 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serialize = new SerializerUnityJson();
             var target = new Target();
 
-            string text = serialize.Serialize(target);
-            var target0 = serialize.Deserialize<Target>(text);
+            string text = serialize.Serialize(target, new Context());
+            var target0 = serialize.Deserialize<Target>(text, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -53,8 +54,8 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         {
             var serialize = new SerializerUnityJson();
 
-            var target0 = serialize.Deserialize<Target>(string.Empty);
-            var target1 = serialize.Deserialize<Target>("{}");
+            var target0 = serialize.Deserialize<Target>(string.Empty, new Context());
+            var target1 = serialize.Deserialize<Target>("{}", new Context());
 
             Assert.NotNull(target0);
             Assert.NotNull(target1);
@@ -68,7 +69,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serialize = new SerializerUnityJson();
             var target = new Target();
 
-            Task<string> task = serialize.SerializeAsync(target);
+            Task<string> task = serialize.SerializeAsync(target, new Context());
 
             while (!task.IsCompleted)
             {
@@ -87,9 +88,9 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serialize = new SerializerUnityJson();
             var target = new Target();
 
-            string text = serialize.Serialize(target);
+            string text = serialize.Serialize(target, new Context());
 
-            Task<Target> task = serialize.DeserializeAsync<Target>(text);
+            Task<Target> task = serialize.DeserializeAsync<Target>(text, new Context());
 
             while (!task.IsCompleted)
             {
@@ -109,7 +110,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serializer = new SerializerUnityJson();
             var target = new Target();
 
-            Target copy = SerializeUtility.Copy(target, serializer);
+            Target copy = SerializeUtility.Copy(target, serializer, new Context());
 
             Assert.NotNull(copy);
             Assert.AreNotEqual(copy, target);

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/TestSerializerUnityJsonBytes.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Runtime.Unity;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -28,7 +29,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
+            byte[] bytes = serializer.Serialize(target, new Context());
 
             Assert.NotNull(bytes);
             Assert.Greater(bytes.Length, 0);
@@ -40,8 +41,8 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
-            var target0 = serializer.Deserialize<Target>(bytes);
+            byte[] bytes = serializer.Serialize(target, new Context());
+            var target0 = serializer.Deserialize<Target>(bytes, new Context());
 
             Assert.AreEqual(target.BoolValue, target0.BoolValue);
             Assert.AreEqual(target.IntValue, target0.IntValue);
@@ -53,8 +54,8 @@ namespace UGF.Serialize.Runtime.Tests.Unity
         {
             var serialize = new SerializerUnityJsonBytes();
 
-            var target0 = serialize.Deserialize<Target>(Array.Empty<byte>());
-            var target1 = serialize.Deserialize<Target>(Array.Empty<byte>());
+            var target0 = serialize.Deserialize<Target>(Array.Empty<byte>(), new Context());
+            var target1 = serialize.Deserialize<Target>(Array.Empty<byte>(), new Context());
 
             Assert.NotNull(target0);
             Assert.NotNull(target1);
@@ -68,7 +69,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
-            Task<byte[]> task = serializer.SerializeAsync(target);
+            Task<byte[]> task = serializer.SerializeAsync(target, new Context());
 
             while (!task.IsCompleted)
             {
@@ -87,9 +88,9 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
-            byte[] bytes = serializer.Serialize(target);
+            byte[] bytes = serializer.Serialize(target, new Context());
 
-            Task<Target> task = serializer.DeserializeAsync<Target>(bytes);
+            Task<Target> task = serializer.DeserializeAsync<Target>(bytes, new Context());
 
             while (!task.IsCompleted)
             {
@@ -109,7 +110,7 @@ namespace UGF.Serialize.Runtime.Tests.Unity
             var serializer = new SerializerUnityJsonBytes();
             var target = new Target();
 
-            Target copy = SerializeUtility.Copy(target, serializer);
+            Target copy = SerializeUtility.Copy(target, serializer, new Context());
 
             Assert.NotNull(copy);
             Assert.AreNotEqual(copy, target);

--- a/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
+++ b/Packages/UGF.Serialize/Editor/UGF.Serialize.Editor.asmdef
@@ -3,8 +3,9 @@
     "rootNamespace": "UGF.Serialize.Editor",
     "references": [
         "GUID:e76e47a0b9e0396439161248a194baa5",
+        "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
         "GUID:abdd615e45137c74ca2ce9c636c78c15",
-        "GUID:6c7389a7d4bbed54e96eb1e71a69798e"
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityJsonEditor.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityJsonEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Runtime;
 using Unity.Profiling;
 using UnityEditor;
@@ -26,12 +27,12 @@ namespace UGF.Serialize.Editor.Unity
             Readable = readable;
         }
 
-        protected override object OnSerialize(object target)
+        protected override object OnSerialize(object target, IContext context)
         {
             return InternalSerialize(target, Readable);
         }
 
-        protected override object OnDeserialize(Type targetType, string data)
+        protected override object OnDeserialize(Type targetType, string data, IContext context)
         {
             return InternalDeserialize(targetType, data);
         }

--- a/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs
+++ b/Packages/UGF.Serialize/Editor/Unity/SerializerUnityYamlEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UGF.EditorTools.Editor.Yaml;
+using UGF.RuntimeTools.Runtime.Contexts;
 using UGF.Serialize.Runtime;
 using Unity.Profiling;
 using Object = UnityEngine.Object;
@@ -19,12 +20,12 @@ namespace UGF.Serialize.Editor.Unity
         }
 #endif
 
-        protected override object OnSerialize(object target)
+        protected override object OnSerialize(object target, IContext context)
         {
             return InternalSerialize(target);
         }
 
-        protected override object OnDeserialize(Type targetType, string data)
+        protected override object OnDeserialize(Type targetType, string data, IContext context)
         {
             return InternalDeserialize(data);
         }

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytes.cs
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 using Unity.Profiling;
 
 namespace UGF.Serialize.Runtime.Bytes
@@ -31,31 +32,31 @@ namespace UGF.Serialize.Runtime.Bytes
             Serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
         }
 
-        protected override object OnSerialize(object target)
+        protected override object OnSerialize(object target, IContext context)
         {
-            return InternalSerialize(Encoding, Serializer, target);
+            return InternalSerialize(Encoding, Serializer, target, context);
         }
 
-        protected override object OnDeserialize(Type targetType, byte[] data)
+        protected override object OnDeserialize(Type targetType, byte[] data, IContext context)
         {
-            return InternalDeserialize(Encoding, Serializer, targetType, data);
+            return InternalDeserialize(Encoding, Serializer, targetType, data, context);
         }
 
-        protected override Task<byte[]> OnSerializeAsync(object target)
+        protected override Task<byte[]> OnSerializeAsync(object target, IContext context)
         {
-            return Task.Run(() => InternalSerialize(Encoding, Serializer, target));
+            return Task.Run(() => InternalSerialize(Encoding, Serializer, target, context));
         }
 
-        protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data)
+        protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data, IContext context)
         {
-            return Task.Run(() => InternalDeserialize(Encoding, Serializer, targetType, data));
+            return Task.Run(() => InternalDeserialize(Encoding, Serializer, targetType, data, context));
         }
 
-        private static byte[] InternalSerialize(Encoding encoding, ISerializer<string> serializer, object target)
+        private static byte[] InternalSerialize(Encoding encoding, ISerializer<string> serializer, object target, IContext context)
         {
             m_markerSerialize.Begin();
 
-            string text = serializer.Serialize(target);
+            string text = serializer.Serialize(target, context);
             byte[] result = encoding.GetBytes(text);
 
             m_markerSerialize.End();
@@ -63,12 +64,12 @@ namespace UGF.Serialize.Runtime.Bytes
             return result;
         }
 
-        private static object InternalDeserialize(Encoding encoding, ISerializer<string> serializer, Type targetType, byte[] data)
+        private static object InternalDeserialize(Encoding encoding, ISerializer<string> serializer, Type targetType, byte[] data, IContext context)
         {
             m_markerDeserialize.Begin();
 
             string text = encoding.GetString(data);
-            object result = serializer.Deserialize(targetType, text);
+            object result = serializer.Deserialize(targetType, text, context);
 
             m_markerDeserialize.End();
 

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Text;
+using UGF.RuntimeTools.Runtime.Encodings;
+using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Bytes
 {
@@ -6,14 +8,17 @@ namespace UGF.Serialize.Runtime.Bytes
     public class SerializerTextToBytesAsset : SerializerAsset<byte[]>
     {
         [SerializeField] private SerializerAsset m_text;
+        [SerializeField] private EncodingType m_encoding;
 
         public SerializerAsset Text { get { return m_text; } set { m_text = value; } }
+        public EncodingType Encoding { get { return m_encoding; } set { m_encoding = value; } }
 
         protected override ISerializer<byte[]> OnBuildTyped()
         {
             var serializer = m_text.Build<ISerializer<string>>();
+            Encoding encoding = EncodingUtility.GetEncoding(m_encoding);
 
-            return new SerializerTextToBytes(serializer);
+            return new SerializerTextToBytes(encoding, serializer);
         }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-using UGF.RuntimeTools.Runtime.Encodings;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Bytes
 {
@@ -8,17 +6,14 @@ namespace UGF.Serialize.Runtime.Bytes
     public class SerializerTextToBytesAsset : SerializerAsset<byte[]>
     {
         [SerializeField] private SerializerAsset m_text;
-        [SerializeField] private EncodingType m_encoding;
 
         public SerializerAsset Text { get { return m_text; } set { m_text = value; } }
-        public EncodingType Encoding { get { return m_encoding; } set { m_encoding = value; } }
 
         protected override ISerializer<byte[]> OnBuildTyped()
         {
             var serializer = m_text.Build<ISerializer<string>>();
-            Encoding encoding = EncodingUtility.GetEncoding(m_encoding);
 
-            return new SerializerTextToBytes(encoding, serializer);
+            return new SerializerTextToBytes(serializer);
         }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatter.cs
+++ b/Packages/UGF.Serialize/Runtime/Formatter/SerializerFormatter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 using Unity.Profiling;
 
 namespace UGF.Serialize.Runtime.Formatter
@@ -45,22 +46,22 @@ namespace UGF.Serialize.Runtime.Formatter
             Formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
         }
 
-        protected override object OnSerialize(object target)
+        protected override object OnSerialize(object target, IContext context)
         {
             return InternalSerialize(Formatter, target);
         }
 
-        protected override object OnDeserialize(Type targetType, byte[] data)
+        protected override object OnDeserialize(Type targetType, byte[] data, IContext context)
         {
             return InternalDeserialize(Formatter, targetType, data);
         }
 
-        protected override Task<byte[]> OnSerializeAsync(object target)
+        protected override Task<byte[]> OnSerializeAsync(object target, IContext context)
         {
             return Task.Run(() => InternalSerialize(Formatter, target));
         }
 
-        protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data)
+        protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data, IContext context)
         {
             return Task.Run(() => InternalDeserialize(Formatter, targetType, data));
         }

--- a/Packages/UGF.Serialize/Runtime/ISerializer.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
@@ -16,25 +17,29 @@ namespace UGF.Serialize.Runtime
         /// Serializes the specified target to data.
         /// </summary>
         /// <param name="target">The target to serialize.</param>
-        object Serialize<T>(T target);
+        /// <param name="context"></param>
+        object Serialize<T>(T target, IContext context);
 
         /// <summary>
         /// Serializes the specified target to data.
         /// </summary>
         /// <param name="target">The target to serialize.</param>
-        object Serialize(object target);
+        /// <param name="context"></param>
+        object Serialize(object target, IContext context);
 
         /// <summary>
         /// Deserializes the specified data to new created object of the specified type.
         /// </summary>
         /// <param name="data">The data used to deserialize new object.</param>
-        T Deserialize<T>(object data);
+        /// <param name="context"></param>
+        T Deserialize<T>(object data, IContext context);
 
         /// <summary>
         /// Deserializes the specified data to new created object of the specified type.
         /// </summary>
         /// <param name="targetType">The data used to deserialize new object.</param>
         /// <param name="data">The type of the new created object.</param>
-        object Deserialize(Type targetType, object data);
+        /// <param name="context"></param>
+        object Deserialize(Type targetType, object data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/ISerializerAsync.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializerAsync.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
     public interface ISerializerAsync : ISerializer
     {
-        Task<object> SerializeAsync<T>(T target);
-        Task<object> SerializeAsync(object target);
-        Task<T> DeserializeAsync<T>(object data);
-        Task<object> DeserializeAsync(Type targetType, object data);
+        Task<object> SerializeAsync<T>(T target, IContext context);
+        Task<object> SerializeAsync(object target, IContext context);
+        Task<T> DeserializeAsync<T>(object data, IContext context);
+        Task<object> DeserializeAsync(Type targetType, object data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/ISerializerAsync`1.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializerAsync`1.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
     public interface ISerializerAsync<TData> : ISerializerAsync, ISerializer<TData>
     {
-        new Task<TData> SerializeAsync<T>(T target);
-        new Task<TData> SerializeAsync(object target);
-        Task<T> DeserializeAsync<T>(TData data);
-        Task<object> DeserializeAsync(Type targetType, TData data);
+        new Task<TData> SerializeAsync<T>(T target, IContext context);
+        new Task<TData> SerializeAsync(object target, IContext context);
+        Task<T> DeserializeAsync<T>(TData data, IContext context);
+        Task<object> DeserializeAsync(Type targetType, TData data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/ISerializer`1.cs
+++ b/Packages/UGF.Serialize/Runtime/ISerializer`1.cs
@@ -1,4 +1,5 @@
 using System;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
@@ -11,25 +12,29 @@ namespace UGF.Serialize.Runtime
         /// Serializes the specified target to data.
         /// </summary>
         /// <param name="target">The target to serialize.</param>
-        new TData Serialize<T>(T target);
+        /// <param name="context"></param>
+        new TData Serialize<T>(T target, IContext context);
 
         /// <summary>
         /// Serializes the specified target to data.
         /// </summary>
         /// <param name="target">The target to serialize.</param>
-        new TData Serialize(object target);
+        /// <param name="context"></param>
+        new TData Serialize(object target, IContext context);
 
         /// <summary>
         /// Deserializes the specified data to new created object of the specified type.
         /// </summary>
         /// <param name="data">The data used to deserialize new object.</param>
-        T Deserialize<T>(TData data);
+        /// <param name="context"></param>
+        T Deserialize<T>(TData data, IContext context);
 
         /// <summary>
         /// Deserializes the specified data to new created object of the specified type.
         /// </summary>
         /// <param name="targetType">The data used to deserialize new object.</param>
         /// <param name="data">The type of the new created object.</param>
-        object Deserialize(Type targetType, TData data);
+        /// <param name="context"></param>
+        object Deserialize(Type targetType, TData data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/SerializeUtility.cs
+++ b/Packages/UGF.Serialize/Runtime/SerializeUtility.cs
@@ -1,38 +1,39 @@
 ﻿using System;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
     public static class SerializeUtility
     {
-        public static async Task<T> CopyAsync<T>(T target, ISerializerAsync serializer) where T : class
+        public static async Task<T> CopyAsync<T>(T target, ISerializerAsync serializer, IContext context) where T : class
         {
-            return (T)await CopyAsync((object)target, serializer);
+            return (T)await CopyAsync((object)target, serializer, context);
         }
 
-        public static async Task<object> CopyAsync(object target, ISerializerAsync serializer)
+        public static async Task<object> CopyAsync(object target, ISerializerAsync serializer, IContext context)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
-            object data = await serializer.SerializeAsync(target);
-            object copy = await serializer.DeserializeAsync(target.GetType(), data);
+            object data = await serializer.SerializeAsync(target, context);
+            object copy = await serializer.DeserializeAsync(target.GetType(), data, context);
 
             return copy;
         }
 
-        public static T Copy<T>(T target, ISerializer serializer) where T : class
+        public static T Copy<T>(T target, ISerializer serializer, IContext context) where T : class
         {
-            return (T)Copy((object)target, serializer);
+            return (T)Copy((object)target, serializer, context);
         }
 
-        public static object Copy(object target, ISerializer serializer)
+        public static object Copy(object target, ISerializer serializer, IContext context)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
             if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
-            object data = serializer.Serialize(target);
-            object copy = serializer.Deserialize(target.GetType(), data);
+            object data = serializer.Serialize(target, context);
+            object copy = serializer.Deserialize(target.GetType(), data, context);
 
             return copy;
         }

--- a/Packages/UGF.Serialize/Runtime/Serializer.cs
+++ b/Packages/UGF.Serialize/Runtime/Serializer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
@@ -6,32 +7,34 @@ namespace UGF.Serialize.Runtime
     {
         public abstract Type DataType { get; }
 
-        public object Serialize<T>(T target)
+        public object Serialize<T>(T target, IContext context)
         {
-            return Serialize((object)target);
+            return Serialize((object)target, context);
         }
 
-        public object Serialize(object target)
+        public object Serialize(object target, IContext context)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
-            return OnSerialize(target);
+            return OnSerialize(target, context);
         }
 
-        public T Deserialize<T>(object data)
+        public T Deserialize<T>(object data, IContext context)
         {
-            return (T)Deserialize(typeof(T), data);
+            return (T)Deserialize(typeof(T), data, context);
         }
 
-        public object Deserialize(Type targetType, object data)
+        public object Deserialize(Type targetType, object data, IContext context)
         {
             if (targetType == null) throw new ArgumentNullException(nameof(targetType));
             if (data == null) throw new ArgumentNullException(nameof(data));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
-            return OnDeserialize(targetType, data);
+            return OnDeserialize(targetType, data, context);
         }
 
-        protected abstract object OnSerialize(object target);
-        protected abstract object OnDeserialize(Type targetType, object data);
+        protected abstract object OnSerialize(object target, IContext context);
+        protected abstract object OnDeserialize(Type targetType, object data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/SerializerAsync.cs
+++ b/Packages/UGF.Serialize/Runtime/SerializerAsync.cs
@@ -1,64 +1,72 @@
 ﻿using System;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
     public abstract class SerializerAsync<TData> : Serializer<TData>, ISerializerAsync<TData>
     {
-        public Task<TData> SerializeAsync<T>(T target)
+        public Task<TData> SerializeAsync<T>(T target, IContext context)
         {
-            return SerializeAsync((object)target);
+            return SerializeAsync((object)target, context);
         }
 
-        public Task<TData> SerializeAsync(object target)
-        {
-            if (target == null) throw new ArgumentNullException(nameof(target));
-
-            return OnSerializeAsync(target);
-        }
-
-        public async Task<T> DeserializeAsync<T>(TData data)
-        {
-            return (T)await DeserializeAsync(typeof(T), data);
-        }
-
-        public Task<object> DeserializeAsync(Type targetType, TData data)
-        {
-            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
-
-            return OnDeserializeAsync(targetType, data);
-        }
-
-        async Task<object> ISerializerAsync.SerializeAsync<T>(T target)
+        public Task<TData> SerializeAsync(object target, IContext context)
         {
             if (target == null) throw new ArgumentNullException(nameof(target));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
-            return await OnSerializeAsync(target);
+            return OnSerializeAsync(target, context);
         }
 
-        async Task<object> ISerializerAsync.SerializeAsync(object target)
+        public async Task<T> DeserializeAsync<T>(TData data, IContext context)
         {
-            if (target == null) throw new ArgumentNullException(nameof(target));
-
-            return await OnSerializeAsync(target);
+            return (T)await DeserializeAsync(typeof(T), data, context);
         }
 
-        async Task<T> ISerializerAsync.DeserializeAsync<T>(object data)
-        {
-            if (data == null) throw new ArgumentNullException(nameof(data));
-
-            return (T)await OnDeserializeAsync(typeof(T), (TData)data);
-        }
-
-        Task<object> ISerializerAsync.DeserializeAsync(Type targetType, object data)
+        public Task<object> DeserializeAsync(Type targetType, TData data, IContext context)
         {
             if (targetType == null) throw new ArgumentNullException(nameof(targetType));
             if (data == null) throw new ArgumentNullException(nameof(data));
+            if (context == null) throw new ArgumentNullException(nameof(context));
 
-            return OnDeserializeAsync(targetType, (TData)data);
+            return OnDeserializeAsync(targetType, data, context);
         }
 
-        protected abstract Task<TData> OnSerializeAsync(object target);
-        protected abstract Task<object> OnDeserializeAsync(Type targetType, TData data);
+        async Task<object> ISerializerAsync.SerializeAsync<T>(T target, IContext context)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return await OnSerializeAsync(target, context);
+        }
+
+        async Task<object> ISerializerAsync.SerializeAsync(object target, IContext context)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return await OnSerializeAsync(target, context);
+        }
+
+        async Task<T> ISerializerAsync.DeserializeAsync<T>(object data, IContext context)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return (T)await OnDeserializeAsync(typeof(T), (TData)data, context);
+        }
+
+        Task<object> ISerializerAsync.DeserializeAsync(Type targetType, object data, IContext context)
+        {
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return OnDeserializeAsync(targetType, (TData)data, context);
+        }
+
+        protected abstract Task<TData> OnSerializeAsync(object target, IContext context);
+        protected abstract Task<object> OnDeserializeAsync(Type targetType, TData data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Serializer`1.cs
+++ b/Packages/UGF.Serialize/Runtime/Serializer`1.cs
@@ -1,4 +1,5 @@
 using System;
+using UGF.RuntimeTools.Runtime.Contexts;
 
 namespace UGF.Serialize.Runtime
 {
@@ -6,31 +7,38 @@ namespace UGF.Serialize.Runtime
     {
         public override Type DataType { get; } = typeof(TData);
 
-        public new TData Serialize<T>(T target)
+        public new TData Serialize<T>(T target, IContext context)
         {
-            return (TData)OnSerialize(target);
+            return Serialize((object)target, context);
         }
 
-        public new TData Serialize(object target)
+        public new TData Serialize(object target, IContext context)
         {
-            return (TData)OnSerialize(target);
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return (TData)OnSerialize(target, context);
         }
 
-        public T Deserialize<T>(TData data)
+        public T Deserialize<T>(TData data, IContext context)
         {
-            return (T)OnDeserialize(typeof(T), data);
+            return (T)OnDeserialize(typeof(T), data, context);
         }
 
-        public object Deserialize(Type targetType, TData data)
+        public object Deserialize(Type targetType, TData data, IContext context)
         {
-            return OnDeserialize(targetType, data);
+            if (targetType == null) throw new ArgumentNullException(nameof(targetType));
+            if (data == null) throw new ArgumentNullException(nameof(data));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            return OnDeserialize(targetType, data, context);
         }
 
-        protected override object OnDeserialize(Type targetType, object data)
+        protected override object OnDeserialize(Type targetType, object data, IContext context)
         {
-            return OnDeserialize(targetType, (TData)data);
+            return OnDeserialize(targetType, (TData)data, context);
         }
 
-        protected abstract object OnDeserialize(Type targetType, TData data);
+        protected abstract object OnDeserialize(Type targetType, TData data, IContext context);
     }
 }

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "UGF.Serialize.Runtime",
     "references": [
         "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
-        "GUID:088d00b6871540e44bce58af1a3f0f17"
+        "GUID:088d00b6871540e44bce58af1a3f0f17",
+        "GUID:16fde9420ef50f34db61e711e19381dd"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
+++ b/Packages/UGF.Serialize/Runtime/UGF.Serialize.Runtime.asmdef
@@ -3,8 +3,7 @@
     "rootNamespace": "UGF.Serialize.Runtime",
     "references": [
         "GUID:6c7389a7d4bbed54e96eb1e71a69798e",
-        "GUID:088d00b6871540e44bce58af1a3f0f17",
-        "GUID:16fde9420ef50f34db61e711e19381dd"
+        "GUID:088d00b6871540e44bce58af1a3f0f17"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJson.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJson.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 using Unity.Profiling;
 using UnityEngine;
 
@@ -35,22 +36,22 @@ namespace UGF.Serialize.Runtime.Unity
             Readable = readable;
         }
 
-        protected override object OnSerialize(object target)
+        protected override object OnSerialize(object target, IContext context)
         {
             return InternalSerialize(target, Readable);
         }
 
-        protected override object OnDeserialize(Type targetType, string data)
+        protected override object OnDeserialize(Type targetType, string data, IContext context)
         {
             return InternalDeserialize(targetType, data);
         }
 
-        protected override Task<string> OnSerializeAsync(object target)
+        protected override Task<string> OnSerializeAsync(object target, IContext context)
         {
             return Task.Run(() => InternalSerialize(target, Readable));
         }
 
-        protected override Task<object> OnDeserializeAsync(Type targetType, string data)
+        protected override Task<object> OnDeserializeAsync(Type targetType, string data, IContext context)
         {
             return Task.Run(() => InternalDeserialize(targetType, data));
         }

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytes.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+using UGF.RuntimeTools.Runtime.Contexts;
 using Unity.Profiling;
 using UnityEngine;
 
@@ -44,22 +45,22 @@ namespace UGF.Serialize.Runtime.Unity
             Encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
-        protected override object OnSerialize(object target)
+        protected override object OnSerialize(object target, IContext context)
         {
             return InternalSerialize(Encoding, target);
         }
 
-        protected override object OnDeserialize(Type targetType, byte[] data)
+        protected override object OnDeserialize(Type targetType, byte[] data, IContext context)
         {
             return InternalDeserialize(Encoding, targetType, data);
         }
 
-        protected override Task<byte[]> OnSerializeAsync(object target)
+        protected override Task<byte[]> OnSerializeAsync(object target, IContext context)
         {
             return Task.Run(() => InternalSerialize(Encoding, target));
         }
 
-        protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data)
+        protected override Task<object> OnDeserializeAsync(Type targetType, byte[] data, IContext context)
         {
             return Task.Run(() => InternalDeserialize(Encoding, targetType, data));
         }

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text;
-using UGF.RuntimeTools.Runtime.Encodings;
 using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Unity
@@ -7,10 +6,6 @@ namespace UGF.Serialize.Runtime.Unity
     [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer Unity Json Bytes", order = 2000)]
     public class SerializerUnityJsonBytesAsset : SerializerAsset<byte[]>
     {
-        [SerializeField] private EncodingType m_encoding;
-
-        public EncodingType Encoding { get { return m_encoding; } set { m_encoding = value; } }
-
         protected override ISerializer<byte[]> OnBuildTyped()
         {
             Encoding encoding = OnCreateEncoding();
@@ -20,7 +15,7 @@ namespace UGF.Serialize.Runtime.Unity
 
         protected virtual Encoding OnCreateEncoding()
         {
-            return EncodingUtility.GetEncoding(m_encoding);
+            return Encoding.Default;
         }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using UGF.RuntimeTools.Runtime.Encodings;
 using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Unity
@@ -6,6 +7,10 @@ namespace UGF.Serialize.Runtime.Unity
     [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer Unity Json Bytes", order = 2000)]
     public class SerializerUnityJsonBytesAsset : SerializerAsset<byte[]>
     {
+        [SerializeField] private EncodingType m_encoding;
+
+        public EncodingType Encoding { get { return m_encoding; } set { m_encoding = value; } }
+
         protected override ISerializer<byte[]> OnBuildTyped()
         {
             Encoding encoding = OnCreateEncoding();
@@ -15,7 +20,7 @@ namespace UGF.Serialize.Runtime.Unity
 
         protected virtual Encoding OnCreateEncoding()
         {
-            return Encoding.Default;
+            return EncodingUtility.GetEncoding(m_encoding);
         }
     }
 }

--- a/Packages/UGF.Serialize/package.json
+++ b/Packages/UGF.Serialize/package.json
@@ -2,7 +2,7 @@
   "name": "com.ugf.serialize",
   "displayName": "UGF.Serialize",
   "version": "4.1.1",
-  "unity": "2020.2",
+  "unity": "2021.1",
   "apiCompatibility": ".NET Standard 2.0",
   "description": "An abstract serialization interface.",
   "author": {

--- a/Packages/UGF.Serialize/package.json
+++ b/Packages/UGF.Serialize/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "com.unity.modules.jsonserialize": "1.0.0",
     "com.ugf.builder": "2.0.1",
-    "com.ugf.editortools": "1.11.1"
+    "com.ugf.editortools": "1.11.1",
+    "com.ugf.runtimetools": "2.2.0"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,6 +14,13 @@
       "dependencies": {},
       "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
     },
+    "com.ugf.runtimetools": {
+      "version": "2.2.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+    },
     "com.ugf.serialize": {
       "version": "file:UGF.Serialize",
       "depth": 0,
@@ -21,7 +28,8 @@
       "dependencies": {
         "com.unity.modules.jsonserialize": "1.0.0",
         "com.ugf.builder": "2.0.1",
-        "com.ugf.editortools": "1.11.1"
+        "com.ugf.editortools": "1.11.1",
+        "com.ugf.runtimetools": "2.2.0"
       }
     },
     "com.unity.ext.nunit": {


### PR DESCRIPTION
- Change package Unity version to `2021.1`.
- Update dependencies: add `com.ugf.runtimetools` of `2.2.0` version.
- Add `IContext` object as argument for `Serialize`, `SerializeAsync`, `Deserialize` and `DeserializeAsync` methods of `ISerializer` and `ISerializerAsync` interfaces.
- Add `IContext` object as argument for `SerializeUtility.Copy` and `CopyAsync` methods.