### PR TITLE
Add encoding selection for serializers

### DIFF
--- a/Assets/UGF.Serialize.Runtime.Tests/Bytes/New Serializer Text To Bytes Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/Bytes/New Serializer Text To Bytes Asset.asset
@@ -13,3 +13,4 @@ MonoBehaviour:
   m_Name: New Serializer Text To Bytes Asset
   m_EditorClassIdentifier: 
   m_text: {fileID: 0}
+  m_encoding: 0

--- a/Assets/UGF.Serialize.Runtime.Tests/Unity/New Serializer Unity Json Bytes Asset.asset
+++ b/Assets/UGF.Serialize.Runtime.Tests/Unity/New Serializer Unity Json Bytes Asset.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cb69df4392e64da88f8ff098b5656c63, type: 3}
   m_Name: New Serializer Unity Json Bytes Asset
   m_EditorClassIdentifier: 
-  m_name: unity-json-bytes
+  m_encoding: 0

--- a/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Bytes/SerializerTextToBytesAsset.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System.Text;
+using UGF.RuntimeTools.Runtime.Encodings;
+using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Bytes
 {
@@ -6,14 +8,17 @@ namespace UGF.Serialize.Runtime.Bytes
     public class SerializerTextToBytesAsset : SerializerAsset<byte[]>
     {
         [SerializeField] private SerializerAsset m_text;
+        [SerializeField] private EncodingType m_encoding;
 
         public SerializerAsset Text { get { return m_text; } set { m_text = value; } }
+        public EncodingType Encoding { get { return m_encoding; } set { m_encoding = value; } }
 
         protected override ISerializer<byte[]> OnBuildTyped()
         {
             var serializer = m_text.Build<ISerializer<string>>();
+            Encoding encoding = EncodingUtility.GetEncoding(m_encoding);
 
-            return new SerializerTextToBytes(serializer);
+            return new SerializerTextToBytes(encoding, serializer);
         }
     }
 }

--- a/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
+++ b/Packages/UGF.Serialize/Runtime/Unity/SerializerUnityJsonBytesAsset.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using UGF.RuntimeTools.Runtime.Encodings;
 using UnityEngine;
 
 namespace UGF.Serialize.Runtime.Unity
@@ -6,16 +7,15 @@ namespace UGF.Serialize.Runtime.Unity
     [CreateAssetMenu(menuName = "Unity Game Framework/Serialize/Serializer Unity Json Bytes", order = 2000)]
     public class SerializerUnityJsonBytesAsset : SerializerAsset<byte[]>
     {
+        [SerializeField] private EncodingType m_encoding;
+
+        public EncodingType Encoding { get { return m_encoding; } set { m_encoding = value; } }
+
         protected override ISerializer<byte[]> OnBuildTyped()
         {
-            Encoding encoding = OnCreateEncoding();
+            Encoding encoding = EncodingUtility.GetEncoding(m_encoding);
 
             return new SerializerUnityJsonBytes(encoding);
-        }
-
-        protected virtual Encoding OnCreateEncoding()
-        {
-            return Encoding.Default;
         }
     }
 }


### PR DESCRIPTION
- Add encoding selection for `SerializerTextToBytesAsset` and `SerializerUnityJsonBytesAsset` serializer assets.
- Remove `SerializerUnityJsonBytesAsset.OnCreateEncoding()` method.